### PR TITLE
[T3-55] 애플로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
 	// slack
 	implementation 'com.slack.api:slack-api-client:1.45.3'
+
+	// bouncycastle
+	implementation 'org.bouncycastle:bcpkix-jdk18on:1.80'
 }
 
 tasks.named('test') {

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/domain/AppleIdTokenPayload.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/domain/AppleIdTokenPayload.java
@@ -1,0 +1,17 @@
+package bitnagil.bitnagil_backend.auth.apple.domain;
+
+import lombok.Getter;
+
+/**
+ * 애플 ID 토큰 페이로드 클래스
+ * 애플 로그인 후 받은 ID 토큰의 페이로드를 매핑하는 클래스
+ */
+@Getter
+public class AppleIdTokenPayload {
+
+    private String sub;
+
+    private String email;
+
+    private String name;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/domain/AppleProperties.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/domain/AppleProperties.java
@@ -1,0 +1,23 @@
+package bitnagil.bitnagil_backend.auth.apple.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 애플 소셜 로그인 관련 설정 프로퍼티 클래스
+ */
+@Component
+@ConfigurationProperties(prefix = "social-login.provider.apple")
+@Getter
+@Setter
+public class AppleProperties {
+
+    private String grantType;
+    private String clientId;
+    private String keyId;
+    private String teamId;
+    private String audience;
+    private String privateKey;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/response/AppleSocialTokenInfoResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/response/AppleSocialTokenInfoResponse.java
@@ -1,0 +1,27 @@
+package bitnagil.bitnagil_backend.auth.apple.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+/**
+ * 애플 소셜 로그인 토큰 정보 응답 클래스
+ * 애플 로그인 후 받은 토큰 정보를 매핑하는 클래스
+ */
+@Getter
+public class AppleSocialTokenInfoResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("id_token")
+    private String idToken;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleAuthClient.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleAuthClient.java
@@ -1,0 +1,28 @@
+package bitnagil.bitnagil_backend.auth.apple.service;
+
+import bitnagil.bitnagil_backend.auth.apple.response.AppleSocialTokenInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * 애플 인증관련 Feign 클라이언트
+ */
+@Component
+@FeignClient(
+        name = "apple-auth",
+        url = "${client.apple-auth.url}",
+        configuration = AppleFeignClientConfiguration.class
+)
+public interface AppleAuthClient {
+
+    // 애플 토큰 검증 API
+    @PostMapping("/auth/token")
+    AppleSocialTokenInfoResponse getIdToken(
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("code") String code
+    );
+}

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleFeignClientConfiguration.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleFeignClientConfiguration.java
@@ -1,0 +1,15 @@
+package bitnagil.bitnagil_backend.auth.apple.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * AppleFeignClient에서 발생하는 예외를 핸들링 하기 위한 설정 클래스
+ */
+public class AppleFeignClientConfiguration {
+
+    @Bean
+    public AppleFeignClientErrorDecoder appleFeignClientErrorDecoder() {
+        return new AppleFeignClientErrorDecoder(new ObjectMapper());
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleFeignClientErrorDecoder.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleFeignClientErrorDecoder.java
@@ -1,0 +1,43 @@
+package bitnagil.bitnagil_backend.auth.apple.service;
+
+import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
+import bitnagil.bitnagil_backend.global.exception.CustomException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+/**
+ * Feign 클라이언트 호출 중 오류가 발생했을 때 예외를 변환하는 ErrorDecoder 구현
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class AppleFeignClientErrorDecoder implements ErrorDecoder {
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Feign Client 호출 시 HTTP 응답 코드가 300 이상인 경우 호출되는 메소드.
+     * 응답 본문이 존재할 경우, ObjectMapper를 사용하여 디코딩을 시도하고 로그로 남깁니다.
+     * 디코딩 실패 시에도 예외를 무시하고 로그만 남긴 후, 공통 CustomException을 반환합니다.
+     * 모든 오류는 공통 에러 코드 (APPLE_FEIGN_CALL_FAILED)로 변환하여 상위 서비스에서 일관되게 처리할 수 있도록 합니다.
+     */
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        Object body = null;
+        if (response != null && response.body() != null) {
+            try {
+                body = objectMapper.readValue(response.body().toString(), Object.class);
+            } catch (IOException e) {
+                log.error("Error decoding response body", e);
+            }
+        }
+
+        log.error("애플 소셜 로그인 Feign API Feign Client 호출 중 오류가 발생되었습니다. body: {}", body);
+
+        throw new CustomException(ErrorCode.APPLE_FEIGN_CALL_FAILED);
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleUserInfoService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleUserInfoService.java
@@ -1,0 +1,77 @@
+package bitnagil.bitnagil_backend.auth.apple.service;
+
+import bitnagil.bitnagil_backend.auth.apple.domain.AppleIdTokenPayload;
+import bitnagil.bitnagil_backend.auth.apple.domain.AppleProperties;
+import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
+import bitnagil.bitnagil_backend.global.exception.CustomException;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.stereotype.Service;
+
+import java.security.PrivateKey;
+import java.security.Security;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleUserInfoService {
+    private final AppleAuthClient appleAuthClient;
+
+    private final AppleProperties appleProperties;
+
+    // 클라이언트에게 받은 authorization code를 통해 APPLE ID 토큰을 가져오고, 해당 토큰의 페이로드를 디코딩하여 반환
+    public AppleIdTokenPayload get(String authorizationCode) {
+
+        String idToken = appleAuthClient.getIdToken(
+                appleProperties.getClientId(),
+                generateClientSecret(),
+                appleProperties.getGrantType(),
+                authorizationCode)
+                .getIdToken();
+
+        return TokenDecoder.decodePayload(idToken, AppleIdTokenPayload.class);
+    }
+
+    // Apple 인증을 위한 ClientSecret 생성
+    private String generateClientSecret() {
+
+        LocalDateTime expiration = LocalDateTime.now().plusMinutes(5);
+
+        String clientSecret = Jwts.builder()
+                .setHeaderParam(JwsHeader.KEY_ID, appleProperties.getKeyId())
+                .setIssuer(appleProperties.getTeamId())
+                .setAudience(appleProperties.getAudience())
+                .setSubject(appleProperties.getClientId())
+                .setExpiration(Date.from(expiration.atZone(ZoneId.systemDefault()).toInstant()))
+                .setIssuedAt(new Date())
+                .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+                .compact();
+
+        return clientSecret;
+    }
+
+    // Apple 인증을 위한 PrivateKey 생성
+    private PrivateKey getPrivateKey() {
+
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+
+        try {
+            byte[] privateKeyBytes = Base64.getDecoder().decode(appleProperties.getPrivateKey());
+
+            PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(privateKeyBytes);
+            return converter.getPrivateKey(privateKeyInfo);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.PRIVATE_KEY_CONVERT_ERROR);
+        }
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/TokenDecoder.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/TokenDecoder.java
@@ -1,0 +1,29 @@
+package bitnagil.bitnagil_backend.auth.apple.service;
+
+import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
+import bitnagil.bitnagil_backend.global.exception.CustomException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Base64;
+
+/**
+ * 애플 로그인 후 받은 ID 토큰을 디코딩하여 페이로드를 추출
+ */
+public class TokenDecoder {
+
+    public static <T> T decodePayload(String token, Class<T> targetClass) {
+
+        String[] tokenParts = token.split("\\.");
+        String payloadJWT = tokenParts[1];
+        Base64.Decoder decoder = Base64.getUrlDecoder();
+        String payload = new String(decoder.decode(payloadJWT));
+        ObjectMapper objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        try {
+            return objectMapper.readValue(payload, targetClass);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.TOKEN_DECODE_ERROR);
+        }
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/global/errorcode/ErrorCode.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/errorcode/ErrorCode.java
@@ -37,7 +37,10 @@ public enum ErrorCode {
     NOT_FOUND_USER("US001", HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
 
     // 소셜 로그인 관련 에러 코드
-    UNSUPPORTED_SOCIAL_TYPE("AU000", HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다.")
+    UNSUPPORTED_SOCIAL_TYPE("SO000", HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
+    APPLE_FEIGN_CALL_FAILED("SO001", HttpStatus.BAD_GATEWAY, "애플 소셜 로그인 Feign API 호출에 실패했습니다."),
+    TOKEN_DECODE_ERROR("SO002", HttpStatus.BAD_REQUEST, "토큰 디코드 중 오류가 발생했습니다."),
+    PRIVATE_KEY_CONVERT_ERROR("SO003", HttpStatus.INTERNAL_SERVER_ERROR, "개인 키 변환 중 오류가 발생했습니다."),
     ;
 
 

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
@@ -21,9 +21,10 @@ public class UserAuthController {
     @PostMapping("/login")
     public CustomResponseDto<TokenResponse> login(
         @RequestParam("socialType") SocialType socialType,
+        @RequestParam(value = "nickname", required = false) String nickname, // 애플로그인 시 nickname은 클라이언트에서 보내준다.
         @RequestHeader("Authorization") String socialAccessToken) {
 
-        TokenResponse tokenResponse = userAuthService.socialLogin(socialType, socialAccessToken);
+        TokenResponse tokenResponse = userAuthService.socialLogin(socialType, nickname, socialAccessToken);
 
         return CustomResponseDto.from(tokenResponse);
     }

--- a/src/main/java/bitnagil/bitnagil_backend/user/domain/UserAuthInfo.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/domain/UserAuthInfo.java
@@ -1,10 +1,10 @@
 package bitnagil.bitnagil_backend.user.domain;
 
+import bitnagil.bitnagil_backend.auth.apple.domain.AppleIdTokenPayload;
 import bitnagil.bitnagil_backend.auth.kakao.response.KakaoUserInfoResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * 소셜 로그인 인증 후 사용자 정보를 통합 관리하기 위한 DTO 클래스입니다.
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
  * 서비스 내부에서 일관된 형태로 사용하기 위해 표준화된 구조로 변환합니다.
  */
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UserAuthInfo {
@@ -30,5 +29,12 @@ public class UserAuthInfo {
             .build();
     }
 
-    // TODO 애플 응답 객체로부터 UserAuthInfo로 변환하는 정적 팩토리 메서드
+    // 애플 응답 객체로부터 UserAuthInfo로 변환하는 정적 팩토리 메서드
+    public static UserAuthInfo from(AppleIdTokenPayload appleIdTokenPayload) {
+        return UserAuthInfo.builder()
+                .socialId(appleIdTokenPayload.getSub())
+                .nickname(appleIdTokenPayload.getName())
+                .email(appleIdTokenPayload.getEmail())
+                .build();
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -1,5 +1,7 @@
 package bitnagil.bitnagil_backend.user.service;
 
+import bitnagil.bitnagil_backend.auth.apple.domain.AppleIdTokenPayload;
+import bitnagil.bitnagil_backend.auth.apple.service.AppleUserInfoService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,14 +36,15 @@ public class UserAuthService {
     private final UserRepository userRepository;
     private final KakaoUserInfoClient kakaoUserInfoClient;
     private final AuthRedisService authRedisService;
+    private final AppleUserInfoService appleUserInfoService;
 
     // 소셜 로그인을 통해 로그인 혹은 회원가입을 진행
     @Transactional
-    public TokenResponse socialLogin(SocialType socialType, String socialAccessToken) {
+    public TokenResponse socialLogin(SocialType socialType, String nickname, String socialAccessToken) {
 
         UserAuthInfo userAuthInfo = getUserAuthInfo(socialType, socialAccessToken);
 
-        User user = signUpOrLogin(socialType, userAuthInfo);
+        User user = signUpOrLogin(socialType, nickname, userAuthInfo);
 
         Token token = jwtProvider.generateToken(user.getUserId());
 
@@ -78,25 +81,28 @@ public class UserAuthService {
                     AUTHORIZATION_TYPE + socialAccessToken);
                 yield UserAuthInfo.from(kakaoUserInfoResponse);
             }
-            case APPLE ->
-                // TODO 애플 회원 정보 요청 API
-                // TODO 애플 회원 정보를 UserAuthInfo에 매핑
-                null;
+            case APPLE -> {
+                AppleIdTokenPayload appleIdTokenPayload = appleUserInfoService.get(socialAccessToken);
+                yield UserAuthInfo.from(appleIdTokenPayload);
+            }
         };
     }
 
-    private User signUpOrLogin(SocialType socialType, UserAuthInfo userAuthInfo) {
+    private User signUpOrLogin(SocialType socialType, String nickname, UserAuthInfo userAuthInfo) {
         return userRepository.findBySocialTypeAndSocialId(socialType, userAuthInfo.getSocialId())
-            .orElseGet(() -> saveMember(socialType, userAuthInfo));
+            .orElseGet(() -> saveMember(socialType, nickname, userAuthInfo));
     }
 
-    private User saveMember(SocialType socialType, UserAuthInfo userAuthInfo) {
+    private User saveMember(SocialType socialType, String nickname, UserAuthInfo userAuthInfo) {
+        // 애플 로그인 시 닉네임은 클라이언트에서 보내준 값을 사용한다.
+        nickname = (socialType == SocialType.APPLE) ? nickname : userAuthInfo.getNickname();
+
         User user = User.builder()
             .socialType(socialType)
             .socialId(userAuthInfo.getSocialId())
             .role(Role.USER)
             .email(userAuthInfo.getEmail())
-            .nickname(userAuthInfo.getNickname())
+            .nickname(nickname)
             .build();
 
         return userRepository.save(user);


### PR DESCRIPTION
## 작업 내역
- 애플 로그인 구현

## 고민한 사항
- 없습니다.

## 리뷰 요청사항
- 애플 로그인의 경우 애플 인증 서버로부터 정보를 받아올 때 닉네임을 받아오지 못하고 클라이언트가 전달해주는 닉네임을 이용해야하기 때문에 기존에 signUpOrLogin 메서드의 인자로 nickname을 추가했습니다.
