### PR TITLE
[T3-61] 애플 로그아웃, 탈퇴 구현

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/domain/AppleIdTokenPayload.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/domain/AppleIdTokenPayload.java
@@ -14,4 +14,10 @@ public class AppleIdTokenPayload {
     private String email;
 
     private String name;
+
+    private String refreshToken;
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleAuthClient.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleAuthClient.java
@@ -25,4 +25,12 @@ public interface AppleAuthClient {
             @RequestParam("grant_type") String grantType,
             @RequestParam("code") String code
     );
+
+    // 애플 탈퇴 API
+    @PostMapping("/auth/revoke")
+    String revoke(
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("token") String refreshToken
+    );
 }

--- a/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleUserInfoService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/apple/service/AppleUserInfoService.java
@@ -2,8 +2,10 @@ package bitnagil.bitnagil_backend.auth.apple.service;
 
 import bitnagil.bitnagil_backend.auth.apple.domain.AppleIdTokenPayload;
 import bitnagil.bitnagil_backend.auth.apple.domain.AppleProperties;
+import bitnagil.bitnagil_backend.auth.apple.response.AppleSocialTokenInfoResponse;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
+import bitnagil.bitnagil_backend.user.domain.User;
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -31,12 +33,18 @@ public class AppleUserInfoService {
     // 클라이언트에게 받은 authorization code를 통해 APPLE ID 토큰을 가져오고, 해당 토큰의 페이로드를 디코딩하여 반환
     public AppleIdTokenPayload get(String authorizationCode) {
 
-        String idToken = appleAuthClient.getIdToken(
+        AppleSocialTokenInfoResponse appleSocialResponse = appleAuthClient.getIdToken(
                 appleProperties.getClientId(),
                 generateClientSecret(),
                 appleProperties.getGrantType(),
-                authorizationCode)
-                .getIdToken();
+                authorizationCode);
+
+        // 실제 유저 정보가 담긴 idToken. 디코딩을 통해 페이로드를 추출
+        String idToken = appleSocialResponse.getIdToken();
+        AppleIdTokenPayload payload = TokenDecoder.decodePayload(idToken, AppleIdTokenPayload.class);
+
+        // 회원 저장 시 refreshToken도 저장하기 위해 AppleSocialTokenInfoResponse에서 가져온 refreshToken을 payload에 설정
+        payload.setRefreshToken(appleSocialResponse.getRefreshToken());
 
         return TokenDecoder.decodePayload(idToken, AppleIdTokenPayload.class);
     }
@@ -73,5 +81,14 @@ public class AppleUserInfoService {
         } catch (Exception e) {
             throw new CustomException(ErrorCode.PRIVATE_KEY_CONVERT_ERROR);
         }
+    }
+
+    // 애플 회원탈퇴 메서드
+    public void unlink(User user) {
+        appleAuthClient.revoke(
+                appleProperties.getClientId(), // yml에 설정한 client id
+                generateClientSecret(), // client secret을 생성
+                user.getRefreshToken() // 애플에서 발급받은 리프레시 토큰
+        );
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtProvider.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtProvider.java
@@ -15,7 +15,7 @@ import org.springframework.util.StringUtils;
 
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
-import bitnagil.bitnagil_backend.user.Repository.UserRepository;
+import bitnagil.bitnagil_backend.user.repository.UserRepository;
 import bitnagil.bitnagil_backend.user.domain.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/CustomOAuth2UserService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/CustomOAuth2UserService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 
 import bitnagil.bitnagil_backend.auth.kakao.domain.CustomOAuth2User;
 import bitnagil.bitnagil_backend.auth.kakao.domain.OAuth2Attribute;
-import bitnagil.bitnagil_backend.user.Repository.UserRepository;
+import bitnagil.bitnagil_backend.user.repository.UserRepository;
 import bitnagil.bitnagil_backend.enums.SocialType;
 import bitnagil.bitnagil_backend.user.domain.User;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/bitnagil/bitnagil_backend/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/handler/GlobalExceptionHandler.java
@@ -37,7 +37,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<Object> handleCustomException(final CustomException e) {
-        log.error("handleCustomException",e.toString(), e);
+        log.error("CustomException 발생 - code: {}, message: {}", e.getErrorCode(), e.getMessage(), e);
         final ErrorCode errorCode = e.getErrorCode();
         sendSlackMessage(e, errorCode);
         return handleExceptionInternal(errorCode);

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
@@ -1,10 +1,7 @@
 package bitnagil.bitnagil_backend.user.controller;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import bitnagil.bitnagil_backend.user.request.UserLoginRequest;
+import org.springframework.web.bind.annotation.*;
 
 import bitnagil.bitnagil_backend.auth.jwt.TokenResponse;
 import bitnagil.bitnagil_backend.enums.SocialType;
@@ -24,37 +21,33 @@ public class UserAuthController implements UserAuthSpec {
 
     @PostMapping("/login")
     public CustomResponseDto<TokenResponse> login(
-        @RequestParam("socialType") SocialType socialType,
-        @RequestParam(value = "nickname", required = false) String nickname, // 애플로그인 시 nickname은 클라이언트에서 보내준다.
-        @RequestHeader("Authorization") String socialAccessToken) {
+            @RequestBody UserLoginRequest userLoginRequest,
+            @RequestHeader("SocialAccessToken") String socialAccessToken) {
 
-        TokenResponse tokenResponse = userAuthService.socialLogin(socialType, nickname, socialAccessToken);
+        TokenResponse tokenResponse = userAuthService.socialLogin(userLoginRequest.getSocialType(), userLoginRequest.getNickname(), socialAccessToken);
 
         return CustomResponseDto.from(tokenResponse);
     }
 
     @PostMapping("/logout")
     public CustomResponseDto<Object> logout(
-        @CurrentUser User user, HttpServletRequest request,
-        @RequestHeader(value = "SocialAccessToken", required = false) String socialAccessToken) {
-        userAuthService.logout(user, request, socialAccessToken);
+            @CurrentUser User user,
+            @RequestHeader(value = "SocialAccessToken", required = false) String socialAccessToken) {
+        userAuthService.logout(user, socialAccessToken);
 
         return CustomResponseDto.from(null);
     }
 
     @PostMapping("/token/reissue")
     public CustomResponseDto<TokenResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
-
         TokenResponse tokenResponse = userAuthService.reissueToken(refreshToken);
 
         return CustomResponseDto.from(tokenResponse);
     }
 
     @PostMapping("/withdrawal")
-    public CustomResponseDto<Object> withdrawal(
-        @CurrentUser User user, HttpServletRequest request,
-        @RequestHeader("SocialAccessToken") String socialAccessToken) {
-        userAuthService.withdrawal(user, request, socialAccessToken);
+    public CustomResponseDto<Object> withdrawal(@CurrentUser User user) {
+        userAuthService.withdrawal(user);
 
         return CustomResponseDto.from(null);
     }

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
@@ -36,7 +36,7 @@ public class UserAuthController implements UserAuthSpec {
     @PostMapping("/logout")
     public CustomResponseDto<Object> logout(
         @CurrentUser User user, HttpServletRequest request,
-        @RequestHeader("SocialAccessToken") String socialAccessToken) {
+        @RequestHeader(value = "SocialAccessToken", required = false) String socialAccessToken) {
         userAuthService.logout(user, request, socialAccessToken);
 
         return CustomResponseDto.from(null);

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
@@ -1,5 +1,7 @@
 package bitnagil.bitnagil_backend.user.controller.spec;
 
+import bitnagil.bitnagil_backend.user.request.UserLoginRequest;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -26,53 +28,42 @@ import jakarta.servlet.http.HttpServletRequest;
 public interface UserAuthSpec {
     @Operation(summary = "소셜회원가입 및 로그인을 수행하고 토큰을 발행합니다.")
     @ApiErrorCodeExamples({
-        ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_USER_INFO_FAILED, ErrorCode.TOKEN_DECODE_ERROR,
+            ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_USER_INFO_FAILED, ErrorCode.TOKEN_DECODE_ERROR,
             ErrorCode.APPLE_FEIGN_CALL_FAILED, ErrorCode.INTERNAL_SERVER_ERROR
     })
     @Parameters({
-        @Parameter(name = "socialType", description = "소셜 로그인 플랫폼을 구분하는 코드입니다.", required = true, example = "KAKAO"),
-        @Parameter(name = "nickname", description = "사용자의 nickname을 설정하는 부분입니다.(애플 로그인의 경우만 설정)", required = false, example = "홍길동"),
-        @Parameter(name = "Authorization", description = "클라이언트에서 발급받은 소셜로그인 플랫폼의 인증코드입니다.(Bearer를 붙히지 않습니다.)", required = true,
-            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
+            @Parameter(name = "SocialAccessToken", description = "소셜로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
+            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER),
     })
     CustomResponseDto<TokenResponse> login(
-        @RequestParam("socialType") SocialType socialType,
-        @RequestParam(value = "nickname", required = false) String nickname,
-        @RequestHeader("Authorization") String socialAccessToken);
+            @RequestBody UserLoginRequest userLoginRequest,
+            @RequestParam("SocialAccessToken") String socialAccessToken);
 
     @Operation(summary = "유저가 로그아웃합니다. 반환 정보는 없습니다.")
     @ApiErrorCodeExamples({
-        ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_LOGOUT_FAILED
+            ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_LOGOUT_FAILED
     })
     @Parameters({
-//        @Parameter(name = "Authorization", description = "서버에서 발급해준 JWT access token 입니다.", required = true,
-//            example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER),
-        @Parameter(name = "SocialAccessToken", description = "소셜로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)(애플 로그아웃 시 해당 값을 설정하지 않습니다.)", required = false,
+            @Parameter(name = "SocialAccessToken", description = "소셜로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)(애플 로그아웃 시 해당 값을 설정하지 않습니다.)", required = false,
             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
     })
-    CustomResponseDto<Object> logout(@CurrentUser User user, HttpServletRequest request,
-        @RequestHeader("SocialAccessToken") String socialAccessToken);
+    CustomResponseDto<Object> logout(
+            @CurrentUser User user,
+            @RequestHeader("SocialAccessToken") String socialAccessToken);
 
     @Operation(summary = "토큰 재발급 요청으로 토큰 관련 정보를 반환합니다.")
     @ApiErrorCodeExamples({
-        ErrorCode.INVALID_JWT_TOKEN, ErrorCode.NOT_FOUND_USER
+            ErrorCode.INVALID_JWT_TOKEN, ErrorCode.NOT_FOUND_USER
     })
     @Parameters({
-        @Parameter(name = "Refresh-Token", description = "서버에서 발급해준 refresh token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
+            @Parameter(name = "Refresh-Token", description = "서버에서 발급해준 refresh token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
     })
     CustomResponseDto<TokenResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken);
 
     @Operation(summary = "소셜로그인으로 연결된 유저가 회원탈퇴합니다. 반환 정보는 없습니다.")
     @ApiErrorCodeExamples({
-        ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_UNLINK_FAILED, ErrorCode.APPLE_FEIGN_CALL_FAILED
+            ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_UNLINK_FAILED, ErrorCode.APPLE_FEIGN_CALL_FAILED
     })
-    @Parameters({
-        @Parameter(name = "Authorization", description = "서버에서 발급해준 JWT access token 입니다.", required = true,
-            example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER),
-        @Parameter(name = "SocialAccessToken", description = "소셜로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
-            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
-    })
-    CustomResponseDto<Object> withdrawal(@CurrentUser User user, HttpServletRequest request,
-        @RequestHeader("SocialAccessToken") String socialAccessToken);
+    CustomResponseDto<Object> withdrawal(@CurrentUser User user);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
@@ -24,16 +24,16 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @Tag(name = ApiTags.USER_AUTH)
 public interface UserAuthSpec {
-    @Operation(summary = "소셜로그인 요청으로 토큰 관련 정보를 반환합니다.")
+    @Operation(summary = "소셜회원가입 및 로그인을 수행하고 토큰을 발행합니다.")
     @ApiErrorCodeExamples({
         ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_USER_INFO_FAILED, ErrorCode.TOKEN_DECODE_ERROR,
-        ErrorCode.INTERNAL_SERVER_ERROR
+            ErrorCode.APPLE_FEIGN_CALL_FAILED, ErrorCode.INTERNAL_SERVER_ERROR
     })
     @Parameters({
-        @Parameter(name = "socialType", description = "social login type", required = true, example = "KAKAO"),
-        @Parameter(name = "nickname", description = "user's social nickname", required = false, example = "yuseok"),
-        @Parameter(name = "Authorization", description = "access tokens issued by social platforms", required = true,
-            example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
+        @Parameter(name = "socialType", description = "소셜 로그인 플랫폼을 구분하는 코드입니다.", required = true, example = "KAKAO"),
+        @Parameter(name = "nickname", description = "사용자의 nickname을 설정하는 부분입니다.(애플 로그인의 경우만 설정)", required = false, example = "홍길동"),
+        @Parameter(name = "Authorization", description = "클라이언트에서 발급받은 소셜로그인 플랫폼의 인증코드입니다.(Bearer를 붙히지 않습니다.)", required = true,
+            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
     })
     CustomResponseDto<TokenResponse> login(
         @RequestParam("socialType") SocialType socialType,
@@ -45,9 +45,9 @@ public interface UserAuthSpec {
         ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_LOGOUT_FAILED
     })
     @Parameters({
-        @Parameter(name = "Authorization", description = "JWT access token (Bearer {token})", required = true,
-            example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER),
-        @Parameter(name = "SocialAccessToken", description = "social access token", required = true,
+//        @Parameter(name = "Authorization", description = "서버에서 발급해준 JWT access token 입니다.", required = true,
+//            example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER),
+        @Parameter(name = "SocialAccessToken", description = "소셜로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)(애플 로그아웃 시 해당 값을 설정하지 않습니다.)", required = false,
             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
     })
     CustomResponseDto<Object> logout(@CurrentUser User user, HttpServletRequest request,
@@ -58,19 +58,19 @@ public interface UserAuthSpec {
         ErrorCode.INVALID_JWT_TOKEN, ErrorCode.NOT_FOUND_USER
     })
     @Parameters({
-        @Parameter(name = "Refresh-Token", description = "리프레시 토큰", required = true,
+        @Parameter(name = "Refresh-Token", description = "서버에서 발급해준 refresh token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
     })
     CustomResponseDto<TokenResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken);
 
     @Operation(summary = "소셜로그인으로 연결된 유저가 회원탈퇴합니다. 반환 정보는 없습니다.")
     @ApiErrorCodeExamples({
-        ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_UNLINK_FAILED
+        ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_UNLINK_FAILED, ErrorCode.APPLE_FEIGN_CALL_FAILED
     })
     @Parameters({
-        @Parameter(name = "Authorization", description = "JWT access token (Bearer {token})", required = true,
+        @Parameter(name = "Authorization", description = "서버에서 발급해준 JWT access token 입니다.", required = true,
             example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER),
-        @Parameter(name = "SocialAccessToken", description = "social access token", required = true,
+        @Parameter(name = "SocialAccessToken", description = "소셜로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", in = ParameterIn.HEADER)
     })
     CustomResponseDto<Object> withdrawal(@CurrentUser User user, HttpServletRequest request,

--- a/src/main/java/bitnagil/bitnagil_backend/user/domain/User.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/domain/User.java
@@ -48,12 +48,15 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String nickname;
 
+    private String refreshToken; // 애플의 경우 탈퇴를 위한 필수값
+
     @Builder
-    public User(SocialType socialType, String socialId, Role role, String email, String nickname) {
+    public User(SocialType socialType, String socialId, Role role, String email, String nickname, String refreshToken) {
         this.socialType = socialType;
         this.socialId = socialId;
         this.role = role;
         this.email = email;
         this.nickname = nickname;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/user/domain/UserAuthInfo.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/domain/UserAuthInfo.java
@@ -19,6 +19,7 @@ public class UserAuthInfo {
     private String socialId;  // 카카오, apple 사용자 고유 ID
     private String nickname;  // 카카오, apple 닉네임
     private String email;     // 카카오, apple 이메일
+    private String refreshToken; // 애플 탈퇴 시 사용되는 리프레시 토큰
 
     // 카카오 응답 객체로부터 UserAuthInfo로 변환하는 정적 팩토리 메서드
     public static UserAuthInfo from(KakaoUserInfoResponse kakaoUserInfoResponse) {
@@ -35,6 +36,7 @@ public class UserAuthInfo {
                 .socialId(appleIdTokenPayload.getSub())
                 .nickname(appleIdTokenPayload.getName())
                 .email(appleIdTokenPayload.getEmail())
+                .refreshToken(appleIdTokenPayload.getRefreshToken())
                 .build();
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/user/repository/UserRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package bitnagil.bitnagil_backend.user.Repository;
+package bitnagil.bitnagil_backend.user.repository;
 
 import java.util.Optional;
 

--- a/src/main/java/bitnagil/bitnagil_backend/user/request/UserLoginRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/request/UserLoginRequest.java
@@ -1,0 +1,23 @@
+package bitnagil.bitnagil_backend.user.request;
+
+import bitnagil.bitnagil_backend.enums.SocialType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "회원 로그인 요청 DTO")
+public class UserLoginRequest {
+
+    @Schema(description = "사용자 닉네임(애플 로그인 시에만 값을 설정한다.)", example = "홍길동")
+    private String nickname;
+
+    @Schema(description = "소셜 로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)",
+            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+            required = true)
+    @NotNull
+    private SocialType socialType;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -13,14 +13,12 @@ import bitnagil.bitnagil_backend.auth.kakao.response.KakaoUserInfoResponse;
 import bitnagil.bitnagil_backend.auth.kakao.service.KakaoUserInfoService;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
-import bitnagil.bitnagil_backend.user.Repository.UserRepository;
+import bitnagil.bitnagil_backend.user.repository.UserRepository;
 import bitnagil.bitnagil_backend.enums.SocialType;
 import bitnagil.bitnagil_backend.auth.jwt.TokenResponse;
 import bitnagil.bitnagil_backend.user.domain.User;
 import bitnagil.bitnagil_backend.enums.Role;
 import bitnagil.bitnagil_backend.user.domain.UserAuthInfo;
-import feign.FeignException;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -78,15 +76,15 @@ public class UserAuthService {
 
     // 로그아웃 - refreshToken 삭제 및 accessToken 블랙리스트 등록
     @Transactional
-    public void logout(User user, HttpServletRequest request, String socialAccessToken) {
-        invalidateToken(user, request);
+    public void logout(User user, String socialAccessToken) {
+        invalidateToken(user);
         invalidateSocialToken(user, socialAccessToken);
     }
 
     // 회원탈퇴 - 회원 관련 정보 삭제 및 소셜과 연결 끊기
     @Transactional
-    public void withdrawal(User user, HttpServletRequest request, String socialAccessToken) {
-        invalidateToken(user, request);
+    public void withdrawal(User user) {
+        invalidateToken(user);
 
         userRepository.deleteById(user.getUserId());
         // TODO soft delete 범위에 대해 추후 논의 후 적용
@@ -128,15 +126,11 @@ public class UserAuthService {
             case KAKAO -> {
                 kakaoUserInfoService.logout(socialAccessToken);
             }
-
-            case APPLE -> {
-                // 애플은 토큰 무효화 API가 없으므로 별도의 처리가 필요 없음
-            }
         }
     }
 
     // 서비스 refreshToken 무효화
-    private void invalidateToken(User user, HttpServletRequest request) {
+    private void invalidateToken(User user) {
         authRedisService.deleteRefreshToken(user.getUserId());
 
         // 서비스 액세스 토큰 블랙리스트 처리

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -117,20 +117,20 @@ public class UserAuthService {
                 kakaoUserInfoService.unlink(user);
             }
             case APPLE -> {
-                // TODO 애플과 연결끊기 로직 추가 예정
+                appleUserInfoService.unlink(user);
             }
         };
     }
 
     // 카카오 accessToken, refreshToken 무효화
-    private void invalidateSocialToken(User user, String accessToken) {
+    private void invalidateSocialToken(User user, String socialAccessToken) {
         switch (user.getSocialType()) {
             case KAKAO -> {
-                kakaoUserInfoService.logout(accessToken);
+                kakaoUserInfoService.logout(socialAccessToken);
             }
 
             case APPLE -> {
-                // TODO 애플 액세스 토큰 무효화
+                // 애플은 토큰 무효화 API가 없으므로 별도의 처리가 필요 없음
             }
         }
     }
@@ -161,6 +161,7 @@ public class UserAuthService {
             .role(Role.USER)
             .email(userAuthInfo.getEmail())
             .nickname(nickname)
+            .refreshToken(userAuthInfo.getRefreshToken()) // 애플 로그인의 경우만 세팅
             .build();
 
         return userRepository.save(user);


### PR DESCRIPTION
## 작업 내역
- 애플 탈퇴
- 스웨거 수정 및 최신화
- user entity 필드 추가(refreshToken)

## 고민한 사항

## 리뷰 요청사항
- 애플은 따로 로그아웃 처리가 없기 때문에 구현하지 않았습니다.
- 회원 탈퇴시에도 feign client로 호출 한번만 하면 탈퇴 처리가 되어서 비교적 간단히 구현했습니다.
- 다만 애플 테스트 앱 환경에서 테스트가 필요하기 때문에 개발 환경으로 배포해서 작동 여부를 확인해봐야할 것 같습니다.
- 스웨거를 일부 수정했습니다. 확인부탁드릴게요

## 추가 요청사항
- 기존에 UserAuthController에 헤더명을 보면 소셜토큰의 경우에도 Authorization 를 설정했는데, 이러면 휴먼에러가 발생할 수 있을것 같습니다.
변수명과 헤더명 모두 소셜 토큰이면 SocialAccessToken로 설정해야할 것 같습니다.
- 추가로 현재 스웨거에는 사용하지 않는 인자들이 설정되어있는데, 이는 제거해야 클라이언트 개발자들이 오해하지 않고 api를 개발할 수 있을것 같습니다.