### PR TITLE
[T3-79] 스웨거 CORS 처리 및 로그아웃 호출 방식 수정

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/auth/jwt/TokenResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/jwt/TokenResponse.java
@@ -18,13 +18,10 @@ public class TokenResponse {
     @NotEmpty
     private String refreshToken;
 
-    private Long accessTokenExpiresIn;
-
     public static TokenResponse of(Token token) {
         return TokenResponse.builder()
             .accessToken(token.getAccessToken())
             .refreshToken(token.getRefreshToken())
-            .accessTokenExpiresIn(token.getAccessTokenExpiresIn())
             .build();
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/KakaoAuthClient.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/KakaoAuthClient.java
@@ -25,8 +25,10 @@ public interface KakaoAuthClient {
     // 카카오 액세스 토큰 무효화 API
     @PostMapping("/v1/user/logout")
     String logout(
-        @RequestHeader("Authorization") String accessToken,
-        @RequestHeader("Content-Type") String contentType);
+        @RequestHeader(value = "Authorization") String adminKey,
+        @RequestHeader(value = "Content-Type") String contentType,
+        @RequestParam("target_id_type") String targetIdType,
+        @RequestParam("target_id") Long socialId);
 
     // 카카오 연동 해제 API (연결 끊기)
     @PostMapping("/v1/user/unlink")

--- a/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/KakaoAuthClient.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/KakaoAuthClient.java
@@ -22,7 +22,7 @@ public interface KakaoAuthClient {
     @GetMapping("/v2/user/me")
     KakaoUserInfoResponse getUserInfo(@RequestHeader("Authorization") String authorizationHeader);
 
-    // 카카오 액세스 토큰 무효화 API
+    // 카카오 로그아웃 API
     @PostMapping("/v1/user/logout")
     String logout(
         @RequestHeader(value = "Authorization") String adminKey,

--- a/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/KakaoUserInfoService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/KakaoUserInfoService.java
@@ -37,10 +37,12 @@ public class KakaoUserInfoService {
     }
 
     // 클라이언트에서 받은 카카오 액세스 토큰으로 카카오 액세스 토큰 무효화
-    public void logout(String accessToken) {
+    public void logout(User user) {
         String socialId = kakaoAuthClient.logout(
-            AUTHORIZATION_TYPE + accessToken,
-            "application/x-www-form-urlencoded;charset=utf-8"
+            KAKAO_AUTH_PREFIX + kakaoAdminKey,
+            "application/x-www-form-urlencoded;charset=utf-8",
+            "user_id",
+            Long.valueOf(user.getSocialId())
         );
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package bitnagil.bitnagil_backend.global.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -18,21 +19,23 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import bitnagil.bitnagil_backend.auth.jwt.JwtAccessDeniedHandler;
 import bitnagil.bitnagil_backend.auth.jwt.JwtAuthenticationEntryPoint;
 import bitnagil.bitnagil_backend.auth.jwt.JwtAuthenticationFilter;
-import bitnagil.bitnagil_backend.auth.kakao.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    @Value("${server-url}")
+    private String serverUrl;
+
     public static final String[] PUBLIC_URLS = {
         "/api/v1/auth/login",
         "/api/v1/auth/token/reissue",
         "/swagger-ui.html",
         "/swagger-ui/**",
         "/v3/api-docs/**",
-        "/api/v1/health-check",
-        "swagger-ui/**"
+        "/api/v1/health-check"
     };
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -53,6 +56,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(PUBLIC_URLS).permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
@@ -63,11 +67,13 @@ public class SecurityConfig {
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
+
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000")); // 실제 배포 시 Origin 제한 권장
+        config.setAllowedOrigins(List.of("http://localhost:3000", serverUrl)); // 실제 배포 시 Origin 제한 권장
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization", "Authorization-refresh"));
+        config.setMaxAge(3600L); // Prelight 결과를 캐싱해서 OPTIONS 요청을 줄이기 위함
         config.setAllowCredentials(false);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,13 +31,13 @@ public class SecurityConfig {
         "/swagger-ui.html",
         "/swagger-ui/**",
         "/v3/api-docs/**",
-        "/api/v1/health-check"
+        "/api/v1/health-check",
+        "swagger-ui/**"
     };
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -52,6 +53,7 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(PUBLIC_URLS).permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
@@ -63,7 +65,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000")); // 실제 배포 시 Origin 제한 권장
+        config.setAllowedOrigins(List.of("http://localhost:3000", "https://dev.bitnagil.com")); // 실제 배포 시 Origin 제한 권장
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization", "Authorization-refresh"));

--- a/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
@@ -53,7 +53,6 @@ public class SecurityConfig {
             )
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(PUBLIC_URLS).permitAll()
-                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000", "https://dev.bitnagil.com")); // 실제 배포 시 Origin 제한 권장
+        config.setAllowedOrigins(List.of("http://localhost:3000")); // 실제 배포 시 Origin 제한 권장
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization", "Authorization-refresh"));

--- a/src/main/java/bitnagil/bitnagil_backend/healthCheck/controller/HealthCheckController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/healthCheck/controller/HealthCheckController.java
@@ -44,7 +44,7 @@ public class HealthCheckController implements HealthCheckSpec {
                 "헬스체크에 성공했습니다. 전달받음 value는 " + val + "입니다."); // 커스텀 응답 메세지
     }
 
-    @PostMapping("/requset")
+    @PostMapping("/request")
     public CustomResponseDto<HealthCheckResponse> health(@RequestBody HealthCheckRequest request) {
         HealthCheckResponse response = HealthCheckResponse.builder()
                 .healthCheckId(request.getHealthCheckId() * 3)

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
@@ -24,16 +24,17 @@ public class UserAuthController implements UserAuthSpec {
             @RequestBody UserLoginRequest userLoginRequest,
             @RequestHeader("SocialAccessToken") String socialAccessToken) {
 
-        TokenResponse tokenResponse = userAuthService.socialLogin(userLoginRequest.getSocialType(), userLoginRequest.getNickname(), socialAccessToken);
+        TokenResponse tokenResponse = userAuthService.socialLogin(
+            userLoginRequest.getSocialType(),
+            userLoginRequest.getNickname(),
+            socialAccessToken);
 
         return CustomResponseDto.from(tokenResponse);
     }
 
     @PostMapping("/logout")
-    public CustomResponseDto<Object> logout(
-            @CurrentUser User user,
-            @RequestHeader(value = "SocialAccessToken", required = false) String socialAccessToken) {
-        userAuthService.logout(user, socialAccessToken);
+    public CustomResponseDto<Object> logout(@CurrentUser User user) {
+        userAuthService.logout(user);
 
         return CustomResponseDto.from(null);
     }

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
@@ -44,12 +44,7 @@ public interface UserAuthSpec {
     @ApiErrorCodeExamples({
             ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_LOGOUT_FAILED
     })
-    @Parameters({
-            @Parameter(name = "SocialAccessToken", description = "소셜로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)(애플 로그아웃 시 해당 값을 설정하지 않습니다.)", required = false,
-            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", in = ParameterIn.HEADER)
-    })
-    CustomResponseDto<Object> logout(User user,
-                                     String socialAccessToken);
+    CustomResponseDto<Object> logout(User user);
 
 
     @Operation(summary = "토큰 재발급 요청으로 토큰 관련 정보를 반환합니다.")

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -74,11 +74,11 @@ public class UserAuthService {
         return TokenResponse.of(token);
     }
 
-    // 로그아웃 - refreshToken 삭제 및 accessToken 블랙리스트 등록
+    // refreshToken 삭제 및 카카오 토큰 무효화
     @Transactional
-    public void logout(User user, String socialAccessToken) {
+    public void logout(User user) {
         invalidateToken(user);
-        invalidateSocialToken(user, socialAccessToken);
+        kakaoUserInfoService.logout(user);
     }
 
     // 회원탈퇴 - 회원 관련 정보 삭제 및 소셜과 연결 끊기
@@ -118,15 +118,6 @@ public class UserAuthService {
                 appleUserInfoService.unlink(user);
             }
         };
-    }
-
-    // 카카오 accessToken, refreshToken 무효화
-    private void invalidateSocialToken(User user, String socialAccessToken) {
-        switch (user.getSocialType()) {
-            case KAKAO -> {
-                kakaoUserInfoService.logout(socialAccessToken);
-            }
-        }
     }
 
     // 서비스 refreshToken 무효화


### PR DESCRIPTION
## 작업 내역
- Swagger의 하위 경로들 서비스 토큰 없이 테스트 가능하도록 허용
   - Swagger의 하위 경로에서 토큰이 필요한데 스웨거에서는 그것을 따로 설정할 수 없거나 용이하지 않기 때문에 허용하였습니다.
   - 이 부분은 서버에 코드가 반영되어야 정상적으로 스웨거로 요청이 수행되는지 확인 가능하기 때문에 병합 후 테스트가 필요 예정입니다.
- 카카오 로그아웃을 어드민 키를 통해 요청을 보내도록 로직을 수정
- 소셜 로그인 시 응답 객체에서 서비스 액세스 토큰 만료기한 필드 삭제

## 고민한 사항

## 리뷰 요청사항
- 간단한 작업이라 가볍게 살펴봐 주시면 좋을 것 같습니다!