### PR TITLE
[T3-79] Security 설정 수정

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
@@ -72,9 +72,9 @@ public class SecurityConfig {
         config.setAllowedOrigins(List.of("http://localhost:3000", serverUrl)); // 실제 배포 시 Origin 제한 권장
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
-        config.setExposedHeaders(List.of("Authorization", "Authorization-refresh"));
+        config.setExposedHeaders(List.of("*"));
         config.setMaxAge(3600L); // Prelight 결과를 캐싱해서 OPTIONS 요청을 줄이기 위함
-        config.setAllowCredentials(false);
+        config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
## 작업 내역
- config.setAllowCredentials(true); 으로 변경
- false로 설정되어 있어 헤더에 값을 실을 수 없는 구조이기 때문에 액세스 토큰이 필요한 api에서 에러가 발생