### PR TITLE
[T3-83] 애플 로그아웃 시 카카오 인증 서버 요청 오류 수정

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -78,7 +78,10 @@ public class UserAuthService {
     @Transactional
     public void logout(User user) {
         invalidateToken(user);
-        kakaoUserInfoService.logout(user);
+        // 카카오의 경우에만 카카오 인증 서버로 로그아웃 요청
+        if(user.getSocialType() == SocialType.KAKAO) {
+            kakaoUserInfoService.logout(user);
+        }
     }
 
     // 회원탈퇴 - 회원 관련 정보 삭제 및 소셜과 연결 끊기


### PR DESCRIPTION
## 작업 내역
- 애플 로그아웃 시 카카오 서버에 엑세스 토큰 무효화 요청을 하지 않도록 수정