### PR TITLE
[T3-87] 루틴 업데이트 엣지 케이스 추가

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtAuthenticationFilter.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtProvider jwtProvider;
+    private final JwtUtil jwtUtil;
     private static final String[] excludedEndpoints = new String[] {"/swagger-ui/**"};
 
     @Override
@@ -37,12 +37,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         throws IOException, ServletException {
 
         // 1. Request Header 에서 토큰을 꺼냄
-        String jwt = jwtProvider.resolveToken(request);
+        String jwt = jwtUtil.resolveToken(request);
 
         // 2. validateToken 으로 토큰 유효성 검사
         // 정상 토큰이면 해당 토큰으로 Authentication 을 가져와서 SecurityContext 에 저장
-        if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
-            Authentication authentication = jwtProvider.getAuthentication(jwt);
+        if (StringUtils.hasText(jwt) && jwtUtil.validateToken(jwt)) {
+            Authentication authentication = jwtUtil.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtProvider.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtProvider.java
@@ -1,6 +1,7 @@
 package bitnagil.bitnagil_backend.auth.jwt;
 
 import java.security.Key;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -110,13 +111,18 @@ public class JwtProvider {
 
     // RefreshToken 혹은 AccessToken으로 인증된 유효 User 조회
     public User findValidUserByRefreshTokenOrAccessToken(String token) {
+        LocalDateTime now = LocalDateTime.now();
+
         // JWT에서 유저 관련 정보 추출 후, UserPk 생성
         UUID userId = UUID.fromString(parseClaims(token).get("userId", String.class));
         Long historySeq = parseClaims(token).get("userHistorySeq", Long.class);
 
         HistoryPk userPk = new HistoryPk(userId, historySeq);
 
-        return userRepository.findByUserPk(userPk).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        return userRepository
+            .findByUserPk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(
+                userId, now, now)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtProvider.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtProvider.java
@@ -31,7 +31,6 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
@@ -115,9 +114,6 @@ public class JwtProvider {
 
         // JWT에서 유저 관련 정보 추출 후, UserPk 생성
         UUID userId = UUID.fromString(parseClaims(token).get("userId", String.class));
-        Long historySeq = parseClaims(token).get("userHistorySeq", Long.class);
-
-        HistoryPk userPk = new HistoryPk(userId, historySeq);
 
         return userRepository
             .findByUserPk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(

--- a/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtUtil.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtUtil.java
@@ -34,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class JwtProvider {
+public class JwtUtil {
     private final AuthRedisService authRedisService;
 
     @Value("${jwt.secret}")

--- a/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/CustomOAuth2UserService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/kakao/service/CustomOAuth2UserService.java
@@ -20,6 +20,7 @@ import bitnagil.bitnagil_backend.user.repository.UserRepository;
 import bitnagil.bitnagil_backend.enums.SocialType;
 import bitnagil.bitnagil_backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * OAuth2 로그인 과정에서 사용자 정보를 처리하는 서비스 클래스입니다.
@@ -28,12 +29,14 @@ import lombok.RequiredArgsConstructor;
  * 외부 소셜 로그인(Kakao 등) 후 사용자 정보를 파싱하고 DB에 저장 또는 조회하여
  * 인증된 {@link CustomOAuth2User} 객체를 반환합니다.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private static final String KAKAO = "kakao";
     private final UserRepository userRepository;
+
 
     /**
      * OAuth2 로그인 시 호출되는 메서드로, 외부 서비스에서 사용자 정보를 받아와 처리합니다.
@@ -43,6 +46,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
      */
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService 진입-----");
+
 
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = delegate.loadUser(userRequest);

--- a/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import bitnagil.bitnagil_backend.auth.jwt.JwtAccessDeniedHandler;
 import bitnagil.bitnagil_backend.auth.jwt.JwtAuthenticationEntryPoint;
 import bitnagil.bitnagil_backend.auth.jwt.JwtAuthenticationFilter;
+import bitnagil.bitnagil_backend.auth.kakao.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -41,6 +42,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -63,6 +65,11 @@ public class SecurityConfig {
                 // USER 권한으로만 접근 가능한 경로(전체)
                 .requestMatchers("/**").hasRole("USER")
                 .anyRequest().authenticated()
+            )
+            .oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuth2UserService)
+                )
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/bitnagil/bitnagil_backend/routine/domain/Routine.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/domain/Routine.java
@@ -4,6 +4,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.UUID;
 
 import bitnagil.bitnagil_backend.global.entity.BaseTimeEntity;
 import bitnagil.bitnagil_backend.global.entity.HistoryPk;
@@ -58,24 +59,19 @@ public class Routine extends BaseTimeEntity {
     @NotNull
     private LocalDateTime historyEndDateTime;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumns({
-        @JoinColumn(name = "user_id", referencedColumnName = "user_id"),
-        @JoinColumn(name = "user_history_seq", referencedColumnName = "history_seq")
-    })
     @NotNull
-    private User user;
+    private UUID userId;
 
     @Builder
     public Routine(HistoryPk routinePk, String name, List<DayOfWeek> repeatDay, LocalTime executionTime,
-        LocalDateTime historyStartDateTime, LocalDateTime historyEndDateTime, User user) {
+        LocalDateTime historyStartDateTime, LocalDateTime historyEndDateTime, UUID userId) {
         this.routinePk = routinePk;
         this.name = name;
         this.repeatDay = repeatDay;
         this.executionTime = executionTime;
         this.historyStartDateTime = historyStartDateTime;
         this.historyEndDateTime = historyEndDateTime;
-        this.user = user;
+        this.userId = userId;
     }
 
     // 이전 루틴의 이력 종료일시를 갱신

--- a/src/main/java/bitnagil/bitnagil_backend/routine/domain/SubRoutine.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/domain/SubRoutine.java
@@ -38,6 +38,9 @@ public class SubRoutine extends BaseTimeEntity {
     private String name;
 
     @NotNull
+    private Integer sortOrder;
+
+    @NotNull
     private LocalDateTime historyStartDateTime;
 
     @NotNull
@@ -47,10 +50,11 @@ public class SubRoutine extends BaseTimeEntity {
     private UUID routineId;
 
     @Builder
-    public SubRoutine(HistoryPk subRoutinePk, String name, LocalDateTime historyStartDateTime, LocalDateTime historyEndDateTime,
-        UUID routineId) {
+    public SubRoutine(HistoryPk subRoutinePk, String name, Integer sortOrder, LocalDateTime historyStartDateTime,
+        LocalDateTime historyEndDateTime, UUID routineId) {
         this.subRoutinePk = subRoutinePk;
         this.name = name;
+        this.sortOrder = sortOrder;
         this.historyStartDateTime = historyStartDateTime;
         this.historyEndDateTime = historyEndDateTime;
         this.routineId = routineId;
@@ -60,4 +64,10 @@ public class SubRoutine extends BaseTimeEntity {
     public void updateHistoryEndDateTime(LocalDateTime updateDateTime) {
         this.historyEndDateTime = updateDateTime;
     }
+
+    // 서브루틴 순서 갱신
+    public void updateSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/SubRoutineInfo.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/SubRoutineInfo.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class SubRoutineInfo {
     private UUID subRoutineId;
     private String subRoutineName;
+    private Integer sortOrder;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/UpdateRoutineRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/UpdateRoutineRequest.java
@@ -39,11 +39,16 @@ public class UpdateRoutineRequest{
     @NotNull
     private LocalTime executionTime;
 
-    @Schema(description = "세부 루틴 이름에 대한 리스트입니다.",
-            example = "[{\"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", \"subRoutineName\": \"손 씻기\"}, " +
-            "{\"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", \"subRoutineName\": \"침대 정리하기\"}, " +
-                "{\"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", \"subRoutineName\": null}]",
-            required = true)
+    @Schema(
+        description = "세부 루틴 수정에 대한 정보입니다. 각각 기존 루틴 유지, 삭제, 새로운 루틴 추가 예시입니다.",
+        example = "["
+            + "{\"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", \"subRoutineName\": \"손 씻기\", \"sortOrder\": 1},"
+            + "{\"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", \"subRoutineName\": null, \"sortOrder\": null},"
+            + "{\"subRoutineId\": null, \"subRoutineName\": \"침대 정리하기\", \"sortOrder\": 2}"
+            + "]",
+        required = true
+    )
     @NotNull
     private List<SubRoutineInfo> subRoutineInfos;
+
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -55,7 +55,7 @@ public class RoutineService {
         // 서브루틴 갱신
         for (SubRoutineInfo subRoutineInfo : request.getSubRoutineInfos()) {
 
-            // 기존 서브루틴 유지
+            // 기존 서브루틴 변경 및 유지
             if (subRoutineInfo.getSubRoutineId() != null && subRoutineInfo.getSubRoutineName() != null) {
                 SubRoutine previousSubRoutine = subRoutineRepository
                     .findBySubRoutinePk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -62,13 +62,15 @@ public class RoutineService {
                         subRoutineInfo.getSubRoutineId(), now, now)
                     .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SUB_ROUTINE));
 
-                // 기존 서브루틴의 이름을 변경한 경우 (이력 갱신)
-                if (!subRoutineInfo.getSubRoutineName().equals(previousSubRoutine.getName())) {
-                    previousSubRoutine.updateHistoryEndDateTime(now);
-                    addUpdatedSubRoutine(subRoutineInfo, previousSubRoutine, now);
-                }
-                else { // 기존 서브루틴을 유지하는 경우 (sortOrder만 업데이트)
-                    previousSubRoutine.updateSortOrder(subRoutineInfo.getSortOrder());
+                    // 기존 서브루틴의 이름을 변경한 경우 (이력 갱신)
+                    if (!subRoutineInfo.getSubRoutineName().equals(previousSubRoutine.getName())) {
+                        previousSubRoutine.updateHistoryEndDateTime(now);
+                        addUpdatedSubRoutine(subRoutineInfo, previousSubRoutine, now);
+                    }
+                    // 기존 서브루틴의 이름을 유지하고, 정렬 순서가 변경된 경우
+                    if (subRoutineInfo.getSubRoutineName().equals(previousSubRoutine.getName()) &&
+                        !previousSubRoutine.getSortOrder().equals(subRoutineInfo.getSortOrder())) {
+                        previousSubRoutine.updateSortOrder(subRoutineInfo.getSortOrder());
                 }
             }
 
@@ -117,11 +119,11 @@ public class RoutineService {
     private void addUpdatedSubRoutine(SubRoutineInfo subRoutineInfo, SubRoutine previousSubRoutine,
         LocalDateTime now) {
         // 서브루틴을 갱신하여 새로운 Row 추가
-        HistoryPk nextSubRoutinePk = new HistoryPk(previousSubRoutine.getSubRoutinePk().getId(),
+        HistoryPk subRoutinePk = new HistoryPk(previousSubRoutine.getSubRoutinePk().getId(),
             previousSubRoutine.getSubRoutinePk().getHistorySeq() + 1);
 
         SubRoutine updateSubRoutine = SubRoutine.builder()
-            .subRoutinePk(nextSubRoutinePk)
+            .subRoutinePk(subRoutinePk)
             .name(subRoutineInfo.getSubRoutineName())
             .sortOrder(subRoutineInfo.getSortOrder())
             .historyStartDateTime(now)

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -52,24 +52,48 @@ public class RoutineService {
             addUpdatedRoutine(user, request, previousRoutine, now);
         }
 
-        // 갱신할 서브 루틴이 있는지 탐색 및 갱신 수행
+        // 서브루틴 갱신
         for (SubRoutineInfo subRoutineInfo : request.getSubRoutineInfos()) {
 
-            SubRoutine previousSubRoutine = subRoutineRepository
-                .findBySubRoutinePk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(
-                    subRoutineInfo.getSubRoutineId(), now, now)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SUB_ROUTINE));
+            // 기존 서브루틴 유지
+            if (subRoutineInfo.getSubRoutineId() != null && subRoutineInfo.getSubRoutineName() != null) {
+                SubRoutine previousSubRoutine = subRoutineRepository
+                    .findBySubRoutinePk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(
+                        subRoutineInfo.getSubRoutineId(), now, now)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SUB_ROUTINE));
 
-            // 갱신할 서브 루틴명이 null이면 해당 서브 루틴을 삭제
-            if (subRoutineInfo.getSubRoutineName() == null) {
-                previousSubRoutine.updateHistoryEndDateTime(now);
-                continue;
+                // 기존 서브루틴의 이름을 변경한 경우 (이력 갱신)
+                if (!subRoutineInfo.getSubRoutineName().equals(previousSubRoutine.getName())) {
+                    previousSubRoutine.updateHistoryEndDateTime(now);
+                    addUpdatedSubRoutine(subRoutineInfo, previousSubRoutine, now);
+                }
+                else { // 기존 서브루틴을 유지하는 경우 (sortOrder만 업데이트)
+                    previousSubRoutine.updateSortOrder(subRoutineInfo.getSortOrder());
+                }
             }
 
-            if (!subRoutineInfo.getSubRoutineName().equals(previousSubRoutine.getName())) {
+            // 기존 서브루틴 삭제
+            if (subRoutineInfo.getSubRoutineId() != null && subRoutineInfo.getSubRoutineName() == null) {
+                SubRoutine removeSubRoutine = subRoutineRepository
+                    .findBySubRoutinePk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(
+                        subRoutineInfo.getSubRoutineId(), now, now)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SUB_ROUTINE));
 
-                previousSubRoutine.updateHistoryEndDateTime(now);
-                addUpdatedSubRoutine(subRoutineInfo, previousSubRoutine, now);
+                removeSubRoutine.updateHistoryEndDateTime(now);
+            }
+
+            // 새로운 서브루틴 추가
+            if (subRoutineInfo.getSubRoutineId() == null && subRoutineInfo.getSubRoutineName() != null) {
+                SubRoutine newSubRoutine = SubRoutine.builder()
+                    .subRoutinePk(new HistoryPk(UUID.randomUUID(), 1L))
+                    .name(subRoutineInfo.getSubRoutineName())
+                    .sortOrder(subRoutineInfo.getSortOrder())
+                    .historyStartDateTime(now)
+                    .historyEndDateTime(TimeUtils.END_DATE_TIME)
+                    .routineId(previousRoutine.getRoutinePk().getId())
+                    .build();
+
+                subRoutineRepository.save(newSubRoutine);
             }
         }
     }
@@ -99,6 +123,7 @@ public class RoutineService {
         SubRoutine updateSubRoutine = SubRoutine.builder()
             .subRoutinePk(nextSubRoutinePk)
             .name(subRoutineInfo.getSubRoutineName())
+            .sortOrder(subRoutineInfo.getSortOrder())
             .historyStartDateTime(now)
             .historyEndDateTime(TimeUtils.END_DATE_TIME)
             .routineId(previousSubRoutine.getRoutineId())
@@ -170,10 +195,12 @@ public class RoutineService {
     }
 
     private void saveSubRoutine(List<String> subRoutineNames, Routine routine, LocalDateTime now) {
+        int sortOrder = 1;
         for (String subRoutineName : subRoutineNames) {
             SubRoutine subRoutine = SubRoutine.builder()
                 .subRoutinePk(new HistoryPk(UUID.randomUUID(), 1L))
                 .name(subRoutineName)
+                .sortOrder(sortOrder++)
                 .historyStartDateTime(now)
                 .historyEndDateTime(TimeUtils.END_DATE_TIME)
                 .routineId(routine.getRoutinePk().getId())

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -125,7 +125,7 @@ public class RoutineService {
                 previousRoutine.getExecutionTime() : request.getExecutionTime())
             .historyStartDateTime(now)
             .historyEndDateTime(TimeUtils.END_DATE_TIME)
-            .user(user)
+            .userId(user.getUserPk().getId())
             .build();
 
         routineRepository.save(updateRoutine);
@@ -146,7 +146,7 @@ public class RoutineService {
                 routineId, now, now)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE));
 
-        if (!user.getUserPk().equals(routine.getUser().getUserPk())) {
+        if (!user.getUserPk().getId().equals(routine.getUserId())) {
             throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
         }
 
@@ -163,7 +163,7 @@ public class RoutineService {
             .executionTime(request.getExecutionTime())
             .historyStartDateTime(now)
             .historyEndDateTime(TimeUtils.END_DATE_TIME)
-            .user(user)
+            .userId(user.getUserPk().getId())
             .build();
 
         return routineRepository.save(routine);

--- a/src/main/java/bitnagil/bitnagil_backend/user/repository/UserRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package bitnagil.bitnagil_backend.user.repository;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -18,6 +19,10 @@ public interface UserRepository extends JpaRepository<User, HistoryPk> {
     // socialType, socialId 기반으로 유저 이력들 특정 후, 이력 시작일시 및 종료일시를 활용해서 현재시간 기준으로 유효한 유저 식별
     Optional<User> findBySocialTypeAndSocialIdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(
         SocialType socialType, String socialId, LocalDateTime historyStartDateBound, LocalDateTime historyEndDateBound);
+
+    // socialId 기반으로 유저 이력들 특정 후, 이력 시작일시 및 종료일시를 활용해서 현재시간 기준으로 유효한 유저 식별
+    Optional<User> findByUserPk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(
+        UUID userId, LocalDateTime historyStartDateBound, LocalDateTime historyEndDateBound);
 
     Optional<User> findByUserPk(HistoryPk userPk);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -13,7 +13,7 @@ import bitnagil.bitnagil_backend.auth.apple.domain.AppleIdTokenPayload;
 import bitnagil.bitnagil_backend.auth.apple.service.AppleUserInfoService;
 import bitnagil.bitnagil_backend.auth.jwt.RefreshToken;
 import bitnagil.bitnagil_backend.auth.jwt.Token;
-import bitnagil.bitnagil_backend.auth.jwt.JwtProvider;
+import bitnagil.bitnagil_backend.auth.jwt.JwtUtil;
 import bitnagil.bitnagil_backend.auth.jwt.AuthRedisService;
 import bitnagil.bitnagil_backend.auth.kakao.response.KakaoUserInfoResponse;
 import bitnagil.bitnagil_backend.auth.kakao.service.KakaoUserInfoService;
@@ -34,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserAuthService {
 
-    private final JwtProvider jwtProvider;
+    private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
     private final AuthRedisService authRedisService;
     private final AppleUserInfoService appleUserInfoService;
@@ -48,7 +48,7 @@ public class UserAuthService {
 
         User user = signUpOrLogin(socialType, nickname, userAuthInfo);
 
-        Token token = jwtProvider.generateToken(user.getUserPk());
+        Token token = jwtUtil.generateToken(user.getUserPk());
 
         return TokenResponse.of(token, user.getRole());
     }
@@ -57,11 +57,11 @@ public class UserAuthService {
     @Transactional
     public TokenResponse reissueToken(String refreshToken) {
 
-        if (!jwtProvider.validateToken(refreshToken)) {
+        if (!jwtUtil.validateToken(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
         }
 
-        User user = jwtProvider.findValidUserByRefreshTokenOrAccessToken(refreshToken);
+        User user = jwtUtil.findValidUserByRefreshTokenOrAccessToken(refreshToken);
 
         RefreshToken refreshTokenByRedis = authRedisService.getRefreshTokenByUserPk(user.getUserPk())
             .orElseThrow(() -> new CustomException(ErrorCode.INVALID_JWT_TOKEN));
@@ -70,7 +70,7 @@ public class UserAuthService {
             throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
         }
 
-        Token token = jwtProvider.generateToken(user.getUserPk());
+        Token token = jwtUtil.generateToken(user.getUserPk());
 
         return TokenResponse.of(token);
     }

--- a/src/test/java/bitnagil/bitnagil_backend/routine/service/RoutineServiceTest.java
+++ b/src/test/java/bitnagil/bitnagil_backend/routine/service/RoutineServiceTest.java
@@ -3,6 +3,7 @@ package bitnagil.bitnagil_backend.routine.service;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import bitnagil.bitnagil_backend.global.entity.HistoryPk;
 import bitnagil.bitnagil_backend.routine.domain.Routine;
 import bitnagil.bitnagil_backend.routine.domain.SubRoutine;
 import bitnagil.bitnagil_backend.routine.repository.RoutineRepository;
@@ -36,20 +38,23 @@ class RoutineServiceTest {
     @Test
     @DisplayName("루틴 및 서브루틴 등록 - 성공 케이스")
     public void registerRoutine_Success() {
-        //TODO 리팩터링 예정
 
-        // given
-        // User user = mock(User.class);
-        // RegisterRoutineRequest registerRoutineRequest = mock(RegisterRoutineRequest.class);
-        //
-        // when(registerRoutineRequest.getRoutineName()).thenReturn("Morning Routine");
-        // when(registerRoutineRequest.getSubRoutineName()).thenReturn(List.of("손 씻기", "양치하기", "세수하기"));
-        //
-        // // when
-        // routineService.registerRoutine(user, registerRoutineRequest);
-        //
-        // // then
-        // verify(routineRepository).save(any(Routine.class));
-        // verify(subRoutineRepository, times(3)).save(any(SubRoutine.class));
+        //given
+        HistoryPk historyPk = new HistoryPk(UUID.randomUUID(), 1L);
+        User user = mock(User.class);
+        Routine routine = mock(Routine.class);
+        RegisterRoutineRequest registerRoutineRequest = mock(RegisterRoutineRequest.class);
+
+        when(user.getUserPk()).thenReturn(historyPk);
+        when(routine.getRoutinePk()).thenReturn(historyPk);
+        when(registerRoutineRequest.getRoutineName()).thenReturn("Morning Routine");
+        when(registerRoutineRequest.getSubRoutineName()).thenReturn(List.of("손 씻기", "양치하기", "세수하기"));
+
+        // when
+        routineService.registerRoutine(user, registerRoutineRequest);
+
+        // then
+        verify(routineRepository).save(any(Routine.class));
+        verify(subRoutineRepository, times(3)).save(any(SubRoutine.class));
     }
 }

--- a/src/test/java/bitnagil/bitnagil_backend/routine/service/RoutineServiceTest.java
+++ b/src/test/java/bitnagil/bitnagil_backend/routine/service/RoutineServiceTest.java
@@ -39,22 +39,24 @@ class RoutineServiceTest {
     @DisplayName("루틴 및 서브루틴 등록 - 성공 케이스")
     public void registerRoutine_Success() {
 
-        //given
-        HistoryPk historyPk = new HistoryPk(UUID.randomUUID(), 1L);
-        User user = mock(User.class);
-        Routine routine = mock(Routine.class);
-        RegisterRoutineRequest registerRoutineRequest = mock(RegisterRoutineRequest.class);
+        // TODO 테스트코드에 대한 브랜치 생성 후 리팩터링 예정
 
-        when(user.getUserPk()).thenReturn(historyPk);
-        when(routine.getRoutinePk()).thenReturn(historyPk);
-        when(registerRoutineRequest.getRoutineName()).thenReturn("Morning Routine");
-        when(registerRoutineRequest.getSubRoutineName()).thenReturn(List.of("손 씻기", "양치하기", "세수하기"));
-
-        // when
-        routineService.registerRoutine(user, registerRoutineRequest);
-
-        // then
-        verify(routineRepository).save(any(Routine.class));
-        verify(subRoutineRepository, times(3)).save(any(SubRoutine.class));
+        // //given
+        // HistoryPk historyPk = new HistoryPk(UUID.randomUUID(), 1L);
+        // User user = mock(User.class);
+        // Routine routine = mock(Routine.class);
+        // RegisterRoutineRequest registerRoutineRequest = mock(RegisterRoutineRequest.class);
+        //
+        // when(user.getUserPk()).thenReturn(historyPk);
+        // when(routine.getRoutinePk()).thenReturn(historyPk);
+        // when(registerRoutineRequest.getRoutineName()).thenReturn("Morning Routine");
+        // when(registerRoutineRequest.getSubRoutineName()).thenReturn(List.of("손 씻기", "양치하기", "세수하기"));
+        //
+        // // when
+        // routineService.registerRoutine(user, registerRoutineRequest);
+        //
+        // // then
+        // verify(routineRepository).save(any(Routine.class));
+        // verify(subRoutineRepository, times(3)).save(any(SubRoutine.class));
     }
 }

--- a/src/test/java/bitnagil/bitnagil_backend/user/service/UserAuthServiceTest.java
+++ b/src/test/java/bitnagil/bitnagil_backend/user/service/UserAuthServiceTest.java
@@ -2,7 +2,7 @@ package bitnagil.bitnagil_backend.user.service;
 
 import bitnagil.bitnagil_backend.auth.apple.service.AppleUserInfoService;
 import bitnagil.bitnagil_backend.auth.jwt.AuthRedisService;
-import bitnagil.bitnagil_backend.auth.jwt.JwtProvider;
+import bitnagil.bitnagil_backend.auth.jwt.JwtUtil;
 import bitnagil.bitnagil_backend.auth.kakao.service.KakaoUserInfoService;
 import bitnagil.bitnagil_backend.enums.Role;
 import bitnagil.bitnagil_backend.enums.SocialType;
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -31,7 +30,7 @@ class UserAuthServiceTest {
     @InjectMocks
     UserAuthService userAuthService;
     @Mock
-    JwtProvider jwtProvider;
+    JwtUtil jwtUtil;
     @Mock
     UserRepository userRepository;
     @Mock


### PR DESCRIPTION
## 작업 내역
- 루틴 업데이트에서 발생할 수 있는 케이스를 다시 정의하여 리팩터링하였습니다.
- JWT AccessToken으로 로그인을 수행할 때 JwtAuthenticationFilter에서 유저 정보를 획득한 것을 기반으로 @CurrentUser에서 User 객체를 가져오게 됩니다. 이때 유저 획득 시 발생하는 유저 정보 쿼리문을 업데이트하였습니다.
     - User의 userId(UUID)와 이력 시작일시, 종료일시를 기반으로 해서 활성 유저가 존재하는지까지만 확인하면 된다고 판단하였습니다. 그래서 historySeq는 고려하지 않은 쿼리메서드를 작성하였습니다.
     ➡️ `findByUserPk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual`
- Routine 테이블에서 User 외래키를 삭제 후 userId(UUID)에 대해 엔티티 필드로 추가시켰습니다. 
- SubRoutine 테이블에 sortOrder 필드를 추가하였습니다. (유저가 설정한 순서를 보장하기 위함)

## 고민한 사항
기존의 JwtProvider이 JWT 생성, 파싱, 검증, 인증 객체 생성 등의 로직을 수행하고 있어서 현재의 클래스명이 해당 역할들을 대변해주지 못하고 있다는 생각이 리팩터링 과정 중 들었습니다. 다만 이 부분을 "클래스 분리를 통해 역할과 책임을 명확하게 하는 것이 필요한가?"를 생각해봤을 때 조금 불필요할 수 있겠다는 생각이 들었습니다.
그 이유는 현재 JWT 관련 로직은 추후 확장 가능성이 현저히 떨어지기 때문에 굳이 클래스 분리를 통해 관리포인트를 늘리는 것이 오히려 트레이드오프를 고려하지 못한 판단이라 생각하였습니다. 그래서 클래스 분리 대신에 JwtUtil이라는 클래스명을 통해 "해당 클래스 하는 역할은 토큰 생성이외에도 다른 역할도 담당하겠구나"라고 인지하도록 변경하였습니다.

위 부분은 제가 JwtProvider 클래스명을 바꾸게 된 계기이고, 중요한 고민 사항은 아니지만 남겨주실 코멘트가 있다면 공유 부탁드립니다!

## 리뷰 요청사항
- 루틴 업데이트 흐름에 대해 다시 한번 검토 부탁드립니다!
- 인증 과정에서 변경한 User의 쿼리 메서드가 적절한지 확인 부탁드립니다.
- 루틴 관련 테이블에 추가한 필드가 적절한 지 확인 부탁드립니다. 