### PR TITLE
[T3-109] 루틴 완료 여부 갱신

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/changedRoutine/repository/ChangedRoutineRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/changedRoutine/repository/ChangedRoutineRepository.java
@@ -8,9 +8,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ChangedRoutineRepository extends JpaRepository<ChangedRoutine, HistoryPk> {
+
+    Optional<ChangedRoutine> findByChangedRoutinePk(HistoryPk changedRoutinePk);
+
+    List<ChangedRoutine> findByChangedRoutinePk_Id(UUID changedRoutineId);
 
     /**
      * 현재 시점을 기준으로 유저의 살아있는 변경루틴 이력을 조회

--- a/src/main/java/bitnagil/bitnagil_backend/changedRoutine/repository/ChangedSubRoutineRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/changedRoutine/repository/ChangedSubRoutineRepository.java
@@ -7,9 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ChangedSubRoutineRepository extends JpaRepository<ChangedSubRoutine, HistoryPk> {
+
+    Optional<ChangedSubRoutine> findByChangedSubRoutinePk(HistoryPk changedSubRoutinePk);
 
     /**
      * 현재 시점을 기준으로 살아있는 변경 서브루틴 이력을 조회

--- a/src/main/java/bitnagil/bitnagil_backend/global/entity/BaseTimeEntity.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/entity/BaseTimeEntity.java
@@ -24,5 +24,5 @@ public class BaseTimeEntity {
     @Column(columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
 
-    private LocalDateTime deletedAt;
+    protected LocalDateTime deletedAt;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/global/errorcode/ErrorCode.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/errorcode/ErrorCode.java
@@ -58,6 +58,17 @@ public enum ErrorCode {
 
     // 서브 루틴 관련 에러 코드
     NOT_FOUND_SUB_ROUTINE("SR001", HttpStatus.NOT_FOUND, "해당 복합 키에 맞는 서브 루틴이 존재하지 않습니다."),
+    SUB_ROUTINE_USER_NOT_MATCHED("SR002", HttpStatus.FORBIDDEN, "서브루틴의 유저 정보와 로그인 유저 정보가 일치하지 않습니다."),
+
+    // 변경 루틴 관련 에러 코드
+    NOT_FOUND_CHANGED_ROUTINE("CR001", HttpStatus.NOT_FOUND, "존재하지 않는 변경 루틴입니다."),
+    CHANGED_ROUTINE_USER_NOT_MATCHED("CR002", HttpStatus.FORBIDDEN, "변경 루틴의 유저 정보와 로그인 유저 정보가 일치하지 않습니다."),
+
+    // 변경 서브루틴 관련 에러 코드
+    NOT_FOUND_CHANGED_SUB_ROUTINE("CSR001", HttpStatus.NOT_FOUND, "존재하지 않는 변경 서브루틴입니다."),
+    CHANGED_SUB_ROUTINE_USER_NOT_MATCHED("CSR002", HttpStatus.FORBIDDEN, "변경 서브루틴의 유저 정보와 로그인 유저 정보가 일치하지 않습니다."),
+
+    // 루틴 타입 관련 에러 코드
 
     // 온보딩 관련 에러 코드
     NOT_FOUND_RECOMMENDED_ROUTINE("ON000", HttpStatus.NOT_FOUND, "조건에 맞는 추천 루틴을 찾을 수 없습니다."),

--- a/src/main/java/bitnagil/bitnagil_backend/routine/controller/RoutineController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/controller/RoutineController.java
@@ -3,7 +3,11 @@ package bitnagil.bitnagil_backend.routine.controller;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
+import bitnagil.bitnagil_backend.routine.request.UpdateRoutineCompletionRequest;
 import jakarta.validation.constraints.NotNull;
+
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -63,5 +67,17 @@ public class RoutineController implements RoutineSpec {
                                                                 @RequestParam @NotNull LocalDate startDate,
                                                                 @RequestParam @NotNull LocalDate endDate) {
         return CustomResponseDto.from(routineService.getRoutines(user, startDate, endDate));
+    }
+
+    /**
+     * 루틴 완료 여부 업데이트
+     * 새 레코드를 생성할 수도, 부분 수정할 수도 있기에 PATCH를 쓰지 않고 POST를 씁니다.
+     */
+    @PostMapping("/completions")
+    public CustomResponseDto<Object> updateRoutineCompletionStatus(@CurrentUser User user,
+        @RequestBody UpdateRoutineCompletionRequest updateRoutineCompletionRequest) {
+        routineService.updateRoutineCompletionStatus(user, updateRoutineCompletionRequest);
+
+        return CustomResponseDto.from(null);
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/controller/RoutineController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/controller/RoutineController.java
@@ -71,7 +71,7 @@ public class RoutineController implements RoutineSpec {
 
     /**
      * 루틴 완료 여부 업데이트
-     * 새 레코드를 생성할 수도, 부분 수정할 수도 있기에 PATCH를 쓰지 않고 POST를 씁니다.
+     * 새 엔티티를 생성할 수도, 부분 수정할 수도 있기에 PATCH를 쓰지 않고 POST를 씁니다.
      */
     @PostMapping("/completions")
     public CustomResponseDto<Object> updateRoutineCompletionStatus(@CurrentUser User user,

--- a/src/main/java/bitnagil/bitnagil_backend/routine/controller/spec/RoutineSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/controller/spec/RoutineSpec.java
@@ -8,8 +8,8 @@ import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExamples;
 import bitnagil.bitnagil_backend.global.swagger.ApiTags;
 import bitnagil.bitnagil_backend.routine.request.RegisterRoutineRequest;
+import bitnagil.bitnagil_backend.routine.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineRequest;
-import bitnagil.bitnagil_backend.routine.request.RoutineSearchRequest;
 import bitnagil.bitnagil_backend.routine.response.RoutineSearchResponse;
 import bitnagil.bitnagil_backend.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,4 +40,8 @@ public interface RoutineSpec {
     @Operation(summary = "루틴 및 서브 루틴을 모두 삭제합니다.")
     @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_ROUTINE, ErrorCode.ROUTINE_USER_NOT_MATCHED})
     CustomResponseDto<Object> deleteRoutine(User user, UUID routineId);
+
+    @Operation(summary = "여러 루틴의 완료 여부를 갱신합니다.")
+    CustomResponseDto<Object> updateRoutineCompletionStatus(User user,
+        UpdateRoutineCompletionRequest updateRoutineCompletionRequest);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/domain/Routine.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/domain/Routine.java
@@ -73,4 +73,9 @@ public class Routine extends BaseTimeEntity {
     public void updateHistoryEndDateTime(LocalDateTime updateDateTime) {
         this.historyEndDateTime = updateDateTime;
     }
+
+    // sort delete
+    public void setDeleteAt(LocalDateTime deleteAt) {
+        this.deletedAt = deleteAt;
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/domain/RoutineCompletion.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/domain/RoutineCompletion.java
@@ -1,0 +1,59 @@
+package bitnagil.bitnagil_backend.routine.domain;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import bitnagil.bitnagil_backend.global.entity.BaseTimeEntity;
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RoutineCompletion extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long routineCompletionId;
+
+    @NotNull
+    private Boolean completeYn;
+
+    @NotNull
+    private LocalDate performedDate;
+
+    @NotNull
+    private UUID routineId;
+
+    @NotNull
+    private Long routineHistorySeq;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(40)", nullable = false)
+    private RoutineType routineType;
+
+    @Builder
+    public RoutineCompletion(Boolean completeYn, LocalDate performedDate, UUID routineId, Long routineHistorySeq,
+        RoutineType routineType) {
+        this.completeYn = completeYn;
+        this.performedDate = performedDate;
+        this.routineId = routineId;
+        this.routineHistorySeq = routineHistorySeq;
+        this.routineType = routineType;
+    }
+
+    public void updateCompleteYn(Boolean completeYn) {
+        this.completeYn = completeYn;
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routine/domain/RoutineCompletion.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/domain/RoutineCompletion.java
@@ -18,6 +18,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 루틴 완료 여부를 관리하는 엔티티 클래스입니다.
+ */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity

--- a/src/main/java/bitnagil/bitnagil_backend/routine/domain/SubRoutine.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/domain/SubRoutine.java
@@ -70,4 +70,8 @@ public class SubRoutine extends BaseTimeEntity {
         this.sortOrder = sortOrder;
     }
 
+    // sort delete
+    public void setDeleteAt(LocalDateTime deleteAt) {
+        this.deletedAt = deleteAt;
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/domain/enums/RoutineType.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/domain/enums/RoutineType.java
@@ -1,0 +1,17 @@
+package bitnagil.bitnagil_backend.routine.domain.enums;
+
+import bitnagil.bitnagil_backend.enums.EnumType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum RoutineType implements EnumType {
+    ROUTINE("루틴"),
+    SUB_ROUTINE("서브루틴"),
+    CHANGED_ROUTINE("변경 루틴"),
+    CHANGED_SUB_ROUTINE("변경 서브루틴"),
+    ;
+
+    private final String description;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineCompletionRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineCompletionRepository.java
@@ -1,0 +1,16 @@
+package bitnagil.bitnagil_backend.routine.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import bitnagil.bitnagil_backend.global.entity.HistoryPk;
+import bitnagil.bitnagil_backend.routine.domain.RoutineCompletion;
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
+
+public interface RoutineCompletionRepository extends JpaRepository<RoutineCompletion, HistoryPk> {
+
+    Optional<RoutineCompletion> findByRoutineIdAndRoutineHistorySeqAndRoutineType(
+        UUID routineId, Long routineHistorySeq, RoutineType routineType);
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineRepository.java
@@ -15,6 +15,7 @@ import java.util.List;
 public interface RoutineRepository extends JpaRepository<Routine, HistoryPk> {
 
     Optional<Routine> findByRoutinePk(HistoryPk routinePk);
+    List<Routine> findByRoutinePk_Id(UUID routinePkId);
 
     // routine_id와 활성 구간(현재 시점) 조건을 모두 만족하는 루틴 조회
     Optional<Routine> findByRoutinePk_IdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/RoutineCompletionInfo.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/RoutineCompletionInfo.java
@@ -34,5 +34,5 @@ public class RoutineCompletionInfo {
         example = "false",
         required = true)
     @NotNull
-    private Boolean isCompleted;
+    private Boolean completeYn;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/RoutineCompletionInfo.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/RoutineCompletionInfo.java
@@ -1,0 +1,38 @@
+package bitnagil.bitnagil_backend.routine.request;
+
+import java.util.UUID;
+
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RoutineCompletionInfo {
+
+    @Schema(description = "갱신할 루틴의 타입입니다.",
+        example = "CHANGED_SUB_ROUTINE",
+        required = true)
+    @NotNull
+    private RoutineType routineType;
+
+    @Schema(description = "루틴의 ID 값입니다.",
+        example = "4fa85f64-5717-4562-b3fc-2c963f66afa6",
+        required = true)
+    @NotNull
+    private UUID routineId;
+
+    @Schema(description = "루틴의 이력순번 값입니다.",
+        example = "2",
+        required = true)
+    @NotNull
+    private Long historySeq;
+
+    @Schema(description = "갱신할 루틴의 완료 여부입니다.",
+        example = "false",
+        required = true)
+    @NotNull
+    private Boolean isCompleted;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/SubRoutineInfo.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/SubRoutineInfo.java
@@ -2,13 +2,27 @@ package bitnagil.bitnagil_backend.routine.request;
 
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class SubRoutineInfo {
+    @Schema(description = "서브루틴 식별자",
+            example = "4fa85f64-5717-4562-b3fc-2c963f66afa6",
+            required = true)
+    @NotNull
     private UUID subRoutineId;
+
+    @Schema(description = "서브루틴 이름",
+            example = "손 씻기",
+            required = true)
     private String subRoutineName;
+
+    @Schema(description = "서브루틴 정렬 순서",
+            example = "1",
+            required = true)
     private Integer sortOrder;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/UpdateRoutineCompletionRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/UpdateRoutineCompletionRequest.java
@@ -1,0 +1,42 @@
+package bitnagil.bitnagil_backend.routine.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "루틴 완료 여부 업데이트 DTO")
+public class UpdateRoutineCompletionRequest {
+
+    @Schema(description = "루틴 완료여부를 갱신하는 날짜입니다.",
+            example = "2025-07-13",
+            required = true)
+    @NotNull
+    private LocalDate performedDate;
+
+    @Schema(
+        description = "변경된 루틴 완료여부에 대한 정보를 담은 리스트입니다.",
+        example = "[" +
+            "{" +
+            "\"routineType\": \"CHANGED_SUB_ROUTINE\", " +
+            "\"routineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", " +
+            "\"historySeq\": 2, " +
+            "\"isCompleted\": false" +
+            "}, " +
+            "{" +
+            "\"routineType\": \"ROUTINE\", " +
+            "\"routineId\": \"123e4567-e89b-12d3-a456-426614174000\", " +
+            "\"historySeq\": 1, " +
+            "\"isCompleted\": true" +
+            "}" +
+            "]",
+        required = true
+    )
+    @NotNull
+    private List<RoutineCompletionInfo> routineCompletionInfos;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/UpdateRoutineRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/UpdateRoutineRequest.java
@@ -40,7 +40,7 @@ public class UpdateRoutineRequest{
     private LocalTime executionTime;
 
     @Schema(
-        description = "세부 루틴 수정에 대한 정보입니다. 각각 기존 루틴 유지, 삭제, 새로운 루틴 추가 예시입니다.",
+        description = "세부 루틴 수정에 대한 정보를 담은 리스트입니다.",
         example = "["
             + "{\"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", \"subRoutineName\": \"손 씻기\", \"sortOrder\": 1},"
             + "{\"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", \"subRoutineName\": null, \"sortOrder\": null},"

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -173,11 +173,11 @@ public class RoutineService {
             // 이미 엔티티가 존재하는 경우 완료여부 갱신
             if (routineCompletion.isPresent()) {
                 RoutineCompletion existingRoutineCompletion = routineCompletion.get();
-                existingRoutineCompletion.updateCompleteYn(routineCompletionInfo.getIsCompleted());
+                existingRoutineCompletion.updateCompleteYn(routineCompletionInfo.getCompleteYn());
             }
             else { // 한번도 체크하지 않아서 엔티티가 생기지 않은 경우 엔티티 생성
                 RoutineCompletion newRoutineCompletion = RoutineCompletion.builder()
-                    .completeYn(routineCompletionInfo.getIsCompleted())
+                    .completeYn(routineCompletionInfo.getCompleteYn())
                     .performedDate(request.getPerformedDate())
                     .routineId(routineCompletionInfo.getRoutineId())
                     .routineHistorySeq(routineCompletionInfo.getHistorySeq())

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -4,6 +4,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,6 +15,11 @@ import bitnagil.bitnagil_backend.changedRoutine.domain.ChangedSubRoutine;
 import bitnagil.bitnagil_backend.changedRoutine.domain.enums.ChangedDivCode;
 import bitnagil.bitnagil_backend.changedRoutine.repository.ChangedRoutineRepository;
 import bitnagil.bitnagil_backend.changedRoutine.repository.ChangedSubRoutineRepository;
+import bitnagil.bitnagil_backend.routine.domain.RoutineCompletion;
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
+import bitnagil.bitnagil_backend.routine.repository.RoutineCompletionRepository;
+import bitnagil.bitnagil_backend.routine.request.RoutineCompletionInfo;
+import bitnagil.bitnagil_backend.routine.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routine.response.RoutineSearchResponse;
 import bitnagil.bitnagil_backend.routine.response.RoutineSearchResultDto;
 import bitnagil.bitnagil_backend.routine.response.SubRoutineSearchResultDto;
@@ -33,10 +39,12 @@ import bitnagil.bitnagil_backend.routine.request.SubRoutineInfo;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineRequest;
 import bitnagil.bitnagil_backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 루틴, 서브루틴에 관련된 서비스 로직을 담은 클래스입니다.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RoutineService {
@@ -45,6 +53,7 @@ public class RoutineService {
     private final SubRoutineRepository subRoutineRepository;
     private final ChangedRoutineRepository changedRoutineRepository;
     private final ChangedSubRoutineRepository changedSubRoutineRepository;
+    private final RoutineCompletionRepository routineCompletionRepository;
 
     // 루틴, 세부루틴을 함께 저장하는 루틴 등록 메서드
     @Transactional
@@ -136,6 +145,88 @@ public class RoutineService {
     @Transactional(readOnly = true)
     public RoutineSearchResponse getRoutines(User user, LocalDate startDate, LocalDate endDate) {
         return queryRoutines(user, startDate, endDate);
+    }
+
+    /**
+     * 루틴의 완료 여부를 갱신하는 메서드입니다.
+     */
+    @Transactional
+    public void updateRoutineCompletionStatus(User user, UpdateRoutineCompletionRequest request) {
+        List<RoutineCompletionInfo> routineCompletionInfos = request.getRoutineCompletionInfos();
+
+        for (RoutineCompletionInfo routineCompletionInfo : routineCompletionInfos) {
+
+            validateRoutineOwnerShip(user, routineCompletionInfo);
+
+            // 기존 완료 여부 엔티티가 존재하는지 조회
+            Optional<RoutineCompletion> routineCompletion = routineCompletionRepository
+                .findByRoutineIdAndRoutineHistorySeqAndRoutineType(
+                    routineCompletionInfo.getRoutineId(),
+                    routineCompletionInfo.getHistorySeq(),
+                    routineCompletionInfo.getRoutineType());
+
+            // 이미 엔티티가 존재하는 경우 완료여부 갱신
+            if (routineCompletion.isPresent()) {
+                RoutineCompletion existingRoutineCompletion = routineCompletion.get();
+                existingRoutineCompletion.updateCompleteYn(routineCompletionInfo.getIsCompleted());
+            }
+            else { // 한번도 체크하지 않아서 엔티티가 생기지 않은 경우 엔티티 생성
+                RoutineCompletion newRoutineCompletion = RoutineCompletion.builder()
+                    .completeYn(routineCompletionInfo.getIsCompleted())
+                    .performedDate(request.getPerformedDate())
+                    .routineId(routineCompletionInfo.getRoutineId())
+                    .routineHistorySeq(routineCompletionInfo.getHistorySeq())
+                    .routineType(routineCompletionInfo.getRoutineType())
+                    .build();
+
+                routineCompletionRepository.save(newRoutineCompletion);
+            }
+        }
+    }
+
+    private void validateRoutineOwnerShip(User user, RoutineCompletionInfo routineCompletionInfo) {
+        RoutineType routineType = routineCompletionInfo.getRoutineType();
+        HistoryPk historyPk = new HistoryPk(routineCompletionInfo.getRoutineId(), routineCompletionInfo.getHistorySeq());
+
+        switch (routineType) {
+            case ROUTINE:
+                Routine routine = routineRepository.findByRoutinePk(historyPk).orElseThrow(
+                    () -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE));
+
+                if (!user.getUserPk().getId().equals(routine.getUserId())) {
+                    throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
+                }
+                break;
+            case SUB_ROUTINE:
+                SubRoutine subRoutine = subRoutineRepository.findBySubRoutinePk(historyPk).orElseThrow(
+                    () -> new CustomException(ErrorCode.NOT_FOUND_SUB_ROUTINE));
+
+                List<Routine> routines = routineRepository.findByRoutinePk_Id(subRoutine.getRoutineId());
+
+                if (!user.getUserPk().getId().equals(routines.get(0).getUserId())) {
+                    throw new CustomException(ErrorCode.SUB_ROUTINE_USER_NOT_MATCHED);
+                }
+                break;
+            case CHANGED_ROUTINE:
+                ChangedRoutine changedRoutine = changedRoutineRepository.findByChangedRoutinePk(historyPk)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHANGED_ROUTINE));
+
+                if (!user.getUserPk().getId().equals(changedRoutine.getUserId())) {
+                    throw new CustomException(ErrorCode.CHANGED_ROUTINE_USER_NOT_MATCHED);
+                }
+                break;
+            case CHANGED_SUB_ROUTINE:
+                ChangedSubRoutine changedSubRoutine = changedSubRoutineRepository.findByChangedSubRoutinePk(historyPk)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHANGED_SUB_ROUTINE));
+
+                List<ChangedRoutine> changedRoutines = changedRoutineRepository.findByChangedRoutinePk_Id(
+                    changedSubRoutine.getChangedRoutineId());
+
+                if (!user.getUserPk().getId().equals(changedRoutines.get(0).getUserId())) {
+                    throw new CustomException(ErrorCode.CHANGED_SUB_ROUTINE_USER_NOT_MATCHED);
+                }
+                break;
+        }
     }
 
     // 갱신된 서브루틴을 SubRoutine 테이블에 새로운 Row 추가

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -175,7 +175,7 @@ public class RoutineService {
                 RoutineCompletion existingRoutineCompletion = routineCompletion.get();
                 existingRoutineCompletion.updateCompleteYn(routineCompletionInfo.getCompleteYn());
             }
-            else { // 한번도 체크하지 않아서 엔티티가 생기지 않은 경우 엔티티 생성
+            else { // 유저가 한번도 체크하지 않아서 엔티티가 생기지 않은 경우 엔티티 생성
                 RoutineCompletion newRoutineCompletion = RoutineCompletion.builder()
                     .completeYn(routineCompletionInfo.getCompleteYn())
                     .performedDate(request.getPerformedDate())
@@ -189,6 +189,7 @@ public class RoutineService {
         }
     }
 
+    // 각 타입의 루틴이 실제로 존재하는 루틴인지, 실제로 유저가 가지고 있는 루틴인지 검증하는 메서드
     private void validateRoutineOwnerShip(User user, RoutineCompletionInfo routineCompletionInfo) {
         RoutineType routineType = routineCompletionInfo.getRoutineType();
         HistoryPk historyPk = new HistoryPk(routineCompletionInfo.getRoutineId(), routineCompletionInfo.getHistorySeq());
@@ -202,6 +203,7 @@ public class RoutineService {
                     throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
                 }
                 break;
+
             case SUB_ROUTINE:
                 SubRoutine subRoutine = subRoutineRepository.findBySubRoutinePk(historyPk).orElseThrow(
                     () -> new CustomException(ErrorCode.NOT_FOUND_SUB_ROUTINE));
@@ -212,6 +214,7 @@ public class RoutineService {
                     throw new CustomException(ErrorCode.SUB_ROUTINE_USER_NOT_MATCHED);
                 }
                 break;
+
             case CHANGED_ROUTINE:
                 ChangedRoutine changedRoutine = changedRoutineRepository.findByChangedRoutinePk(historyPk)
                     .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHANGED_ROUTINE));
@@ -220,6 +223,7 @@ public class RoutineService {
                     throw new CustomException(ErrorCode.CHANGED_ROUTINE_USER_NOT_MATCHED);
                 }
                 break;
+
             case CHANGED_SUB_ROUTINE:
                 ChangedSubRoutine changedSubRoutine = changedSubRoutineRepository.findByChangedSubRoutinePk(historyPk)
                     .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHANGED_SUB_ROUTINE));

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -131,12 +131,17 @@ public class RoutineService {
 
         Routine routine = validateRoutineOwnership(routineId, user, now);
 
-        // 기존 루틴, 서브 루틴의 이력 종료일시를 갱신합니다.
+        // 기존 루틴, 서브 루틴의 이력 종료일시 및 deleteAt 갱신
         routine.updateHistoryEndDateTime(now);
+        routine.setDeleteAt(now);
 
-        // 서브 루틴을 순회하면서 이력 종료일시 갱신
+        // 서브 루틴을 순회하면서 이력 종료일시 및 deleteAt 갱신
         subRoutineRepository.findByRoutineId(routineId)
-            .forEach(subRoutine -> subRoutine.updateHistoryEndDateTime(now));
+            .forEach(subRoutine -> {
+                subRoutine.updateHistoryEndDateTime(now);
+                subRoutine.setDeleteAt(now);
+            });
+
     }
 
     /**


### PR DESCRIPTION
## 작업 내역
- 루틴 완료 여부(RoutineCompletion) 엔티티 생성 및 갱신 로직 추가
- 루틴, 서브 루틴 엔티티에서 deleteAt을 설정하기 위해 BaseTimeEntity에서 deleteAt을 protected로 변경
- 추후 2차 릴리즈를 위해 개발하며 '당일 수정 혹은 미루기' 기능에 의해 기존 루틴이 변경 루틴으로 들어갈 때 해당 날짜의 루틴에 대한 RoutineCompletion을 삭제하는 작업을 추가할 예정입니다. 
사실 루틴을 조회할 때 애초에 변경하기 전 기존 날짜에 대해 루틴을 조회하지 않기 때문에 삭제를 꼭 하지 않아도 될 수 있습니다. 이 부분도 추후 개발 시에 논의가 필요해 보입니다. 제가 잊어버릴 수 있어 적어뒀습니다.

## 고민한 사항
1. 루틴 완료 여부 테이블에 각 루틴마다의 historySeq를 가지고 있는데 이를 클라이언트에서 받아오려면 홈 조회시에 response에 각 루틴의 historySeq가 추가되어야 할 것 같습니다.
현재 홈 조회 작업 중에 이미 수정하셨을 수 있는데, 새로운 테이블을 만들며 발생된 부분이라 혹시 공유가 안된 부분일까 하여 노티 남겨드립니다!

2. 루틴 완료 여부 테이블은 매일 존재해야 유저가 체크를 누르고 요청이 왔을 때 해당 테이블의 completeYn 필드 갱신이 가능할 것이라 생각하였습니다. 하지만 Spring Scheduler를 사용하여 매일 00:00:01 시각에 모든 유저의 당일에 필요한 모든 루틴에 대해 루틴 완료 여부 row를 생성하는 것은 리소스가 많이 들기도 하고 유저가 앱을 사용하지 않는 날에는 불필요한 리소스가 될 것이라 판단하였습니다.
그래서 루틴 완료 여부를 갱신 시에 해당 routineId, routineHistorySeq, routineType에 해당하는 데이터가 없는 경우 생성해주고 갱신하도록 하였습니다. 이렇게 하면 루틴 완료 여부의 생성에 대한 리소스를 최소화할 수 있습니다.

     이에 따라 홈 조회시에 해당 루틴의 완료 여부를 조회하실 때, empty로 반환이 된다면 해당 루틴은 '완료하지 않은' 상태로 처리해주시면 됩니다.

3. 개발 회의실 카톡방에 오늘자로 올려놓은 '루틴 완료 여부 갱신'에 대한 요청을 어떻게 보내야 다양한 유저 케이스에 대응할 수 있을지 논의하였습니다. 이에 따라 프론트 개발진은 단일 루틴에 대해 갱신 api 요청을 보내는 것이 아닌 유저가 연속적으로 루틴 완료에 체크하는 것을 수집하여 List<UpdateRoutineCompletionRequest>로 보내주기로 하였습니다. 이에 맞춰 서비스 로직을 변경하였습니다.

4. 루틴 완료 여부를 갱신하기 이전에 루틴이 실제로 존재하는지, 로그인한 유저가 가지고 있는 루틴인지 검증하는 로직(validateRoutineOwnerShip)이 있습니다. 이때 요청받은 routineType이 서브루틴, 변경 서브루틴인 경우에는 유저의 userId와 서브루틴, 변경 서브루틴의 상위 루틴 테이블인 루틴, 변경 루틴을 조회하고, 그 엔티티에서 userId를 꺼내와 비교하게 됩니다.
그리고 루틴과 서브루틴은 연관관계를 맺지 않아서 서브루틴에 있는 routineId로 List<Routine>으로 조회해오게 됩니다. 유저가 등록한 루틴이 많다면 꽤 많은 탐색이 필요해서 성능이 비교적 떨어질 수 있다고 느꼈습니다. 
현 시점에서 성능 문제가 발생되지 않겠지만 추후에 이 과정의 성능을 높이기 위해 루틴과 서브루틴을 다시 연관관계를 맺는 것이 바람직할지 또는 걱정할만한 성능 문제는 아닌지 궁금하여 여쭤보고 싶습니다!

## 리뷰 요청사항
- 고민한 사항을 확인해보시고 오류 혹은 다른 의견이 있으시면 코멘트 부탁드려요~!
- 갱신에 대한 서비스 로직 검토 부탁드려요~!
- deleteAt은 제가 주로 작업한 루틴, 서브루틴 로직에서만 수정하여 변경루틴, 변경 서브루틴의 경우에는 필환님이 수정해주시면 좋을 것 같습니다! (혹시 제가 컨텍스트를 놓쳐 수정하지 못한 부분이 생길까봐 부탁드립니다~!)