### PR TITLE
[T3-107] 홈 루틴 조회 API 수정

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/changedRoutine/repository/ChangedRoutineRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/changedRoutine/repository/ChangedRoutineRepository.java
@@ -21,7 +21,7 @@ public interface ChangedRoutineRepository extends JpaRepository<ChangedRoutine, 
      * 현재 시점을 기준으로 유저의 살아있는 변경루틴 이력을 조회
      * historyStartDateTime < systime <= historyEndDateTime
      */
-    List<ChangedRoutine> findByUserIdAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqualAndChangedRoutineDateBetween(
+    List<ChangedRoutine> findByUserIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqualAndChangedRoutineDateBetween(
             UUID userId,
             LocalDateTime now1,
             LocalDateTime now2,

--- a/src/main/java/bitnagil/bitnagil_backend/changedRoutine/repository/ChangedSubRoutineRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/changedRoutine/repository/ChangedSubRoutineRepository.java
@@ -18,7 +18,7 @@ public interface ChangedSubRoutineRepository extends JpaRepository<ChangedSubRou
      * 현재 시점을 기준으로 살아있는 변경 서브루틴 이력을 조회
      * historyStartDateTime < systime <= historyEndDateTime
      */
-    List<ChangedSubRoutine> findByChangedRoutineIdAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
+    List<ChangedSubRoutine> findByChangedRoutineIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
             UUID changedRoutineId,
             LocalDateTime now1,
             LocalDateTime now2

--- a/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineCompletionRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineCompletionRepository.java
@@ -1,6 +1,5 @@
 package bitnagil.bitnagil_backend.routine.repository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +10,6 @@ import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 
 public interface RoutineCompletionRepository extends JpaRepository<RoutineCompletion, HistoryPk> {
 
-    Optional<RoutineCompletion> findByRoutineIdAndRoutineHistorySeqAndRoutineType(
+    RoutineCompletion findByRoutineIdAndRoutineHistorySeqAndRoutineType(
         UUID routineId, Long routineHistorySeq, RoutineType routineType);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineRepository.java
@@ -26,9 +26,15 @@ public interface RoutineRepository extends JpaRepository<Routine, HistoryPk> {
      * 현재 시점을 기준으로 유저의 살아있는 루틴 이력을 조회
      * historyStartDate < systime <= historyEndDate
      */
-    List<Routine> findByUserIdAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
+    List<Routine> findByUserIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
             UUID userId,
             LocalDateTime now1,
             LocalDateTime now2
+    );
+
+    List<Routine> findByUserIdAndDeletedAtIsNullAndHistoryStartDateTimeLessThanEqualAndHistoryEndDateTimeGreaterThanEqual(
+            UUID userId,
+            LocalDateTime endDateTime,
+            LocalDateTime startDateTime
     );
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/repository/SubRoutineRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/repository/SubRoutineRepository.java
@@ -24,7 +24,7 @@ public interface SubRoutineRepository extends JpaRepository<SubRoutine, HistoryP
      * 현재 시점을 기준으로 살아있는 서브루틴 이력을 조회
      * historyStartDateTime < systime <= historyEndDateTime
      */
-    List<SubRoutine> findByRoutineIdAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
+    List<SubRoutine> findByRoutineIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
             UUID routineId,
             LocalDateTime now1,
             LocalDateTime now2

--- a/src/main/java/bitnagil/bitnagil_backend/routine/response/RoutineSearchResultDto.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/response/RoutineSearchResultDto.java
@@ -1,10 +1,12 @@
 package bitnagil.bitnagil_backend.routine.response;
 
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
@@ -17,7 +19,8 @@ public class RoutineSearchResultDto {
     private UUID routineId; // 루틴 ID
     @Schema(example = "물마시기")
     private String routineName; // 루틴 이름
-    // todo: 완료여부 추가
+    @Schema(example = "[MONDAY, WEDNESDAY, FRIDAY]")
+    private List<DayOfWeek> repeatDay; // 반복 요일
     @Schema(example = "08:30:00")
     private LocalTime executionTime; // 루틴 실행 시간
     private List<SubRoutineSearchResultDto> subRoutineSearchResultDto; // 서브루틴 목록
@@ -25,4 +28,6 @@ public class RoutineSearchResultDto {
     private Boolean modifiedYn; // 수정 여부
     @Schema(example = "false", description = "true: 완료, false: 미완료 (default는 false)")
     private Boolean completeYn; // 완료 여부 (true: 완료, false: 미완료)
+    @Schema(example = "ROUTINE", description = "루틴 구분을 위한 타입. 추후 루틴 완료 처리시 해당값을 그대로 전달")
+    private RoutineType routineType; // 루틴 타입 (ROUTINE, SUB_ROUTINE, CHANGED_ROUTINE, CHANGED_SUB_ROUTINE)
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/response/RoutineSearchResultDto.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/response/RoutineSearchResultDto.java
@@ -15,8 +15,10 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class RoutineSearchResultDto {
-    @Schema(example = "1")
+    @Schema(example = "046259d9-352a-4fd3-9855-c4539fb19242")
     private UUID routineId; // 루틴 ID
+    @Schema(example = "1")
+    private Long historySeq; // 루틴 이력 시퀀스
     @Schema(example = "물마시기")
     private String routineName; // 루틴 이름
     @Schema(example = "[MONDAY, WEDNESDAY, FRIDAY]")

--- a/src/main/java/bitnagil/bitnagil_backend/routine/response/SubRoutineSearchResultDto.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/response/SubRoutineSearchResultDto.java
@@ -1,5 +1,6 @@
 package bitnagil.bitnagil_backend.routine.response;
 
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,4 +22,6 @@ public class SubRoutineSearchResultDto {
     private Integer sortOrder; // 정렬 순서
     @Schema(example = "false", description = "true: 완료, false: 미완료 (default는 false)")
     private Boolean completeYn; // 완료 여부 (true: 완료, false: 미완료)
+    @Schema(example = "SUB_ROUTINE", description = "루틴 구분을 위한 타입. 추후 루틴 완료 처리시 해당값을 그대로 전달")
+    private RoutineType routineType; // 루틴 타입 (ROUTINE, SUB_ROUTINE, CHANGED_ROUTINE, CHANGED_SUB_ROUTINE)
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/response/SubRoutineSearchResultDto.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/response/SubRoutineSearchResultDto.java
@@ -12,8 +12,10 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class SubRoutineSearchResultDto {
-    @Schema(example = "1")
+    @Schema(example = "046259d9-352a-4fd3-9855-c4539fb19242")
     private UUID subRoutineId; // 서브 루틴 ID
+    @Schema(example = "1")
+    private Long historySeq;
     @Schema(example = "물 10초만에 마시기")
     private String subRoutineName; // 서브 루틴 이름
     @Schema(example = "false")

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -374,6 +374,7 @@ public class RoutineService {
 
                         SubRoutineSearchResultDto subRoutineSearchResultDto = SubRoutineSearchResultDto.builder()
                                 .subRoutineId(subRoutine.getSubRoutinePk().getId())
+                                .historySeq(subRoutine.getSubRoutinePk().getHistorySeq())
                                 .subRoutineName(subRoutine.getName())
                                 .sortOrder(subRoutine.getSortOrder())
                                 .modifiedYn(false) // 서브루틴은 일시적인 수정(당일삭제, 미루기 등)이 아니므로 변경여부를 false로 설정
@@ -392,6 +393,7 @@ public class RoutineService {
 
                     RoutineSearchResultDto routineSearchResultDto = RoutineSearchResultDto.builder()
                             .routineId(routine.getRoutinePk().getId())
+                            .historySeq(routine.getRoutinePk().getHistorySeq())
                             .routineName(routine.getName())
                             .repeatDay(routine.getRepeatDay())
                             .executionTime(routine.getExecutionTime())
@@ -440,6 +442,7 @@ public class RoutineService {
 
                     SubRoutineSearchResultDto changedSubRoutineSearchResultDto = SubRoutineSearchResultDto.builder()
                             .subRoutineId(changedSubRoutine.getChangedSubRoutinePk().getId())
+                            .historySeq(changedSubRoutine.getChangedSubRoutinePk().getHistorySeq())
                             .subRoutineName(changedSubRoutine.getChangedSubRoutineName())
                             .sortOrder(changedSubRoutine.getSortOrder())
                             .modifiedYn(true)
@@ -458,6 +461,7 @@ public class RoutineService {
 
                 RoutineSearchResultDto changedRoutineSearchResultDto = RoutineSearchResultDto.builder()
                         .routineId(changedRoutine.getChangedRoutinePk().getId())
+                        .historySeq(changedRoutine.getChangedRoutinePk().getHistorySeq())
                         .routineName(changedRoutine.getChangedRoutineName())
 //                        .repeatDay(changedRoutine.getRepeatDay()) // 변경 루틴은 반복 요일이 없으므로 주석 처리(추후 2차에서는 이런 변경 루틴에 대해 어떻게 처리할지 고민)
                         .executionTime(changedRoutine.getChangedExecutionTime())

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -4,11 +4,11 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.time.LocalTime;
 
 import bitnagil.bitnagil_backend.changedRoutine.domain.ChangedRoutine;
 import bitnagil.bitnagil_backend.changedRoutine.domain.ChangedSubRoutine;
@@ -164,15 +164,15 @@ public class RoutineService {
             validateRoutineOwnerShip(user, routineCompletionInfo);
 
             // 기존 완료 여부 엔티티가 존재하는지 조회
-            Optional<RoutineCompletion> routineCompletion = routineCompletionRepository
+            RoutineCompletion routineCompletion = routineCompletionRepository
                 .findByRoutineIdAndRoutineHistorySeqAndRoutineType(
                     routineCompletionInfo.getRoutineId(),
                     routineCompletionInfo.getHistorySeq(),
                     routineCompletionInfo.getRoutineType());
 
             // 이미 엔티티가 존재하는 경우 완료여부 갱신
-            if (routineCompletion.isPresent()) {
-                RoutineCompletion existingRoutineCompletion = routineCompletion.get();
+            if (routineCompletion != null) {
+                RoutineCompletion existingRoutineCompletion = routineCompletion;
                 existingRoutineCompletion.updateCompleteYn(routineCompletionInfo.getCompleteYn());
             }
             else { // 유저가 한번도 체크하지 않아서 엔티티가 생기지 않은 경우 엔티티 생성
@@ -343,70 +343,82 @@ public class RoutineService {
         LocalDateTime now = LocalDateTime.now();
 
         // 루틴 테이블의 살아있는 이력을 모두 조회한다.
-        List<Routine> routines = routineRepository.findByUserIdAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
+        // todo: 추후 루틴 시작일시와 종료일시가 추가되면 조회 기간안에 루틴 종료일시 혹은 시작일시가 존재하는지를 파악하여 해당 기간내에 존재하는 루틴만 조회하도록 수정이 필요하다.
+        List<Routine> routines = routineRepository.findByUserIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
                 user.getUserPk().getId(), now, now
-        );
-
-        // 변경 루틴 테이블의 변경된 루틴 날짜가 startDate ~ endDate인 살아있는 이력을 모두 조회한다.
-        List<ChangedRoutine> changedRoutines = changedRoutineRepository.findByUserIdAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqualAndChangedRoutineDateBetween(
-                user.getUserPk().getId(), now, now, startDate, endDate
         );
 
         // 루틴을 날짜별로 묶어서 반환할 Map을 날짜별로 초기화 해놓는다.
         Map<LocalDate, List<RoutineSearchResultDto>> routinesByDateResponse = new HashMap<>();
         for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
-            routinesByDateResponse.put(date, new ArrayList<>());
-        }
+            routinesByDateResponse.put(date, new ArrayList<>()); // 현재 날짜의 Map을 초기화
 
-        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
-            DayOfWeek currentDayOfWeek = date.getDayOfWeek(); // 현재 날짜의 요일
-            // 루틴 먼저 현재 날짜에 그대로 담는다.
+            DayOfWeek currentDayOfWeek = date.getDayOfWeek(); // 현재 날짜의 요일(ex: 2025-07-22 -> TUESDAY)
+            // 조회해온 루틴을 순회하면서 현재 날짜의 요일과 루틴의 반복요일이 일치하는 경우 Map에 해당 루틴을 담는다.
             for (Routine routine : routines) {
                 List<DayOfWeek> repeatDays = routine.getRepeatDay();
 
-                // 루틴의 반복요일이 현재 날짜의 요일과 일치하는지 확인(일치하는 경우에만 해당 날짜에 루틴을 담는다.)
+                // 루틴의 반복요일이 현재 날짜의 요일과 일치하는지 확인
                 if (repeatDays.contains(currentDayOfWeek)) {
                     // 현재 루틴의 ID를 FK로 가지는 서브루틴 조회
-                    List<SubRoutine> subRoutines = subRoutineRepository.findByRoutineIdAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
+                    List<SubRoutine> subRoutines = subRoutineRepository.findByRoutineIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
                             routine.getRoutinePk().getId(), now, now
                     );
                     // 서브루틴 List DTO 생성
                     List<SubRoutineSearchResultDto> subRoutineSearchResultList = new ArrayList<>();
                     for (SubRoutine subRoutine : subRoutines) {
+
+                        // 서브 루틴 완료 여부 조회
+                        RoutineCompletion subRoutineCompletion = routineCompletionRepository.findByRoutineIdAndRoutineHistorySeqAndRoutineType(
+                                subRoutine.getSubRoutinePk().getId(), subRoutine.getSubRoutinePk().getHistorySeq(), RoutineType.SUB_ROUTINE);
+
                         SubRoutineSearchResultDto subRoutineSearchResultDto = SubRoutineSearchResultDto.builder()
                                 .subRoutineId(subRoutine.getSubRoutinePk().getId())
                                 .subRoutineName(subRoutine.getName())
                                 .sortOrder(subRoutine.getSortOrder())
-                                .modifiedYn(false)
-                                .completeYn(false)
+                                .modifiedYn(false) // 서브루틴은 일시적인 수정(당일삭제, 미루기 등)이 아니므로 변경여부를 false로 설정
+                                .completeYn(subRoutineCompletion == null ? false : subRoutineCompletion.getCompleteYn())
+                                .routineType(RoutineType.SUB_ROUTINE)
                                 .build();
                         subRoutineSearchResultList.add(subRoutineSearchResultDto);
                     }
-                    // 서브루틴 정렬
+
+                    // 서브루틴을 sortOrder 순으로 정렬
                     subRoutineSearchResultList.sort((a, b) -> a.getSortOrder().compareTo(b.getSortOrder()));
-                    // todo: 완료여부 추가
+
+                    // 루틴 완료 여부 조회
+                    RoutineCompletion routineCompletion = routineCompletionRepository.findByRoutineIdAndRoutineHistorySeqAndRoutineType(
+                            routine.getRoutinePk().getId(), routine.getRoutinePk().getHistorySeq(), RoutineType.ROUTINE);
+
                     RoutineSearchResultDto routineSearchResultDto = RoutineSearchResultDto.builder()
                             .routineId(routine.getRoutinePk().getId())
                             .routineName(routine.getName())
+                            .repeatDay(routine.getRepeatDay())
                             .executionTime(routine.getExecutionTime())
-                            .subRoutineSearchResultDto(subRoutineSearchResultList) // 서브루틴은 나중에 추가
-                            .modifiedYn(false) // 기존의 반복 루틴은 수정 여부가 false
-                            .completeYn(false)
+                            .subRoutineSearchResultDto(subRoutineSearchResultList)
+                            .modifiedYn(false) // 루틴은 일시적인 수정(당일삭제, 미루기 등)이 아니므로 변경여부를 false로 설정
+                            .completeYn(routineCompletion == null ? false : routineCompletion.getCompleteYn())
+                            .routineType(RoutineType.ROUTINE)
                             .build();
                     routinesByDateResponse.get(date).add(routineSearchResultDto); // map에 현재날짜에 해당하는 루틴을 담는다.
                 }
             }
         }
 
-        // 변경 루틴을 하나씩 순회하면서 원본 루틴과 겹치는 날짜가 있다면, 원본 루틴을 Map에서 제거하고, 변경 루틴을 넣는다.
-        for (ChangedRoutine changedRoutine : changedRoutines) {
-            LocalDate originalRoutineDate = changedRoutine.getOriginalRoutineDate();
-            LocalDate changedRoutineDate = changedRoutine.getChangedRoutineDate();
+        // 변경 루틴 테이블의 변경된 루틴 날짜가 startDate ~ endDate인 이력을 모두 조회한다.
+        List<ChangedRoutine> changedRoutines = changedRoutineRepository.findByUserIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqualAndChangedRoutineDateBetween(
+                user.getUserPk().getId(), now, now, startDate, endDate
+        );
 
-            // 1. 먼저 원본 루틴 날짜에 해당하는 루틴 목록을 가져온다.
+        // 변경 루틴을 하나씩 순회하면서 원본 루틴과 겹치는 날짜가 있다면, 원본 루틴을 Map에서 제거하고, 변경 루틴을 넣는다.(삭제는 제외)
+        for (ChangedRoutine changedRoutine : changedRoutines) {
+            LocalDate originalRoutineDate = changedRoutine.getOriginalRoutineDate(); // 원본 루틴 수행 날짜
+            LocalDate changedRoutineDate = changedRoutine.getChangedRoutineDate(); // 변경 루틴 수행 날짜
+
+            // 1. 먼저 Map에서 원본 루틴 날짜에 해당하는 루틴 목록을 가져온다.
             List<RoutineSearchResultDto> routineListForOriginalDate = routinesByDateResponse.get(originalRoutineDate);
             if (!routineListForOriginalDate.isEmpty()) {
-                // 2. 원본 루틴과 ID가 일치하는 루틴을 제거
+                // 2. 원본 루틴 ID와 변경 루틴의 원본 루틴 ID가 일치하는 루틴을 제거
                 routineListForOriginalDate.removeIf(dto -> dto.getRoutineId().equals(changedRoutine.getRoutineId()));
             }
 
@@ -414,20 +426,25 @@ public class RoutineService {
             if (changedRoutine.getChangedDivCode() != ChangedDivCode.TODAY_DELETE) {
 
                 // 현재 변경루틴의 ID를 FK로 가지는 변경서브루틴 조회
-                List<ChangedSubRoutine> changedSubRoutines = changedSubRoutineRepository.findByChangedRoutineIdAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
+                List<ChangedSubRoutine> changedSubRoutines = changedSubRoutineRepository.findByChangedRoutineIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
                         changedRoutine.getChangedRoutinePk().getId(), now, now
                 );
 
                 // 변경 서브루틴 List DTO 생성
-                // todo: 완료여부 추가
                 List<SubRoutineSearchResultDto> changedSubRoutineSearchResultList = new ArrayList<>();
                 for (ChangedSubRoutine changedSubRoutine : changedSubRoutines) {
+
+                    // 변경 서브 루틴완료 여부를 파악
+                    RoutineCompletion changedSubRoutineCompletion = routineCompletionRepository.findByRoutineIdAndRoutineHistorySeqAndRoutineType(
+                            changedSubRoutine.getChangedSubRoutinePk().getId(), changedSubRoutine.getChangedSubRoutinePk().getHistorySeq(), RoutineType.CHANGED_SUB_ROUTINE);
+
                     SubRoutineSearchResultDto changedSubRoutineSearchResultDto = SubRoutineSearchResultDto.builder()
                             .subRoutineId(changedSubRoutine.getChangedSubRoutinePk().getId())
                             .subRoutineName(changedSubRoutine.getChangedSubRoutineName())
                             .sortOrder(changedSubRoutine.getSortOrder())
                             .modifiedYn(true)
-                            .completeYn(false)
+                            .completeYn(changedSubRoutineCompletion == null ? false : changedSubRoutineCompletion.getCompleteYn())
+                            .routineType(RoutineType.CHANGED_SUB_ROUTINE)
                             .build();
                     changedSubRoutineSearchResultList.add(changedSubRoutineSearchResultDto);
                 }
@@ -435,14 +452,19 @@ public class RoutineService {
                 // 변경 서브루틴 정렬
                 changedSubRoutineSearchResultList.sort((a, b) -> a.getSortOrder().compareTo(b.getSortOrder()));
 
-                // todo: 완료여부 추가
+                // 변경루틴 완료여부 조회
+                RoutineCompletion changedRoutineCompletion = routineCompletionRepository.findByRoutineIdAndRoutineHistorySeqAndRoutineType(
+                        changedRoutine.getChangedRoutinePk().getId(), changedRoutine.getChangedRoutinePk().getHistorySeq(), RoutineType.CHANGED_ROUTINE);
+
                 RoutineSearchResultDto changedRoutineSearchResultDto = RoutineSearchResultDto.builder()
                         .routineId(changedRoutine.getChangedRoutinePk().getId())
                         .routineName(changedRoutine.getChangedRoutineName())
+//                        .repeatDay(changedRoutine.getRepeatDay()) // 변경 루틴은 반복 요일이 없으므로 주석 처리(추후 2차에서는 이런 변경 루틴에 대해 어떻게 처리할지 고민)
                         .executionTime(changedRoutine.getChangedExecutionTime())
                         .subRoutineSearchResultDto(changedSubRoutineSearchResultList)
                         .modifiedYn(true) // 변경 루틴은 수정 여부가 true
-                        .completeYn(false)
+                        .completeYn(changedRoutineCompletion == null ? false : changedRoutineCompletion.getCompleteYn())
+                        .routineType(RoutineType.CHANGED_ROUTINE)
                         .build();
 
                 routinesByDateResponse.get(changedRoutine.getChangedRoutineDate()).add(changedRoutineSearchResultDto);


### PR DESCRIPTION
## 작업 내역
- 루틴, 서브루틴, 변경루틴, 변경서브루틴 조회 시 deletedAt is Null 조건 추가
- 루틴 조회 API 완료여부 응답값 추가(완료여부 엔티티 조회시 null or not null에 따른 응답값 분기 처리)
- `findByRoutineIdAndRoutineHistorySeqAndRoutineType` 메서드 Optional 제거(null 가능성 존재로 인해)

## 고민한 사항
- 루틴 조회시 존재하는 다양한 엣지케이스를 같이 고민해봐요
- 빠른시일내로 질문게시판에 기획적인 부분의 고려사항을 정리해볼게요

## 리뷰 요청사항
전반적으로 API 테스트는 완료했고, `queryRoutines` 부분을 중점적으로 봐주시면 됩니다~