### PR TITLE
[T3-111] 선택한 요일(당일)만 루틴 삭제

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtAccessDeniedHandler.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
+import bitnagil.bitnagil_backend.global.response.ErrorResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -37,8 +38,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-        CustomResponseDto<String> errorResponse = CustomResponseDto.from(ErrorCode.FORBIDDEN_USER,
-            accessDeniedException.getMessage());
+        ErrorResponseDto errorResponse = ErrorResponseDto.from(ErrorCode.FORBIDDEN_USER);
         objectMapper.writeValue(response.getWriter(), errorResponse);
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/bitnagil/bitnagil_backend/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
+import bitnagil.bitnagil_backend.global.response.ErrorResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -37,8 +38,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-        CustomResponseDto<String> errorResponse = CustomResponseDto.from(ErrorCode.UNAUTHENTICATED_USER,
-            authException.getMessage());
+        ErrorResponseDto errorResponse = ErrorResponseDto.from(ErrorCode.UNAUTHENTICATED_USER);
         objectMapper.writeValue(response.getWriter(), errorResponse);
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/enums/Role.java
+++ b/src/main/java/bitnagil/bitnagil_backend/enums/Role.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 public enum Role implements EnumType {
 
     GUEST("ROLE_GUEST"),
-    USER("ROLE_USER");
+    USER("ROLE_USER"),
+    WITHDRAWN("ROLE_WITHDRAWN");
 
     private final String description;
 

--- a/src/main/java/bitnagil/bitnagil_backend/global/errorcode/ErrorCode.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/errorcode/ErrorCode.java
@@ -68,7 +68,9 @@ public enum ErrorCode {
     NOT_FOUND_CHANGED_SUB_ROUTINE("CSR001", HttpStatus.NOT_FOUND, "존재하지 않는 변경 서브루틴입니다."),
     CHANGED_SUB_ROUTINE_USER_NOT_MATCHED("CSR002", HttpStatus.FORBIDDEN, "변경 서브루틴의 유저 정보와 로그인 유저 정보가 일치하지 않습니다."),
 
-    // 루틴 타입 관련 에러 코드
+    // 루틴 완료 여부 관련 에러 코드
+    ROUTINE_ID_MISMATCH("RC001", HttpStatus.BAD_REQUEST, "루틴 완료 여부 테이블에서 조회된 routineId와 요청받은 routineId가 다릅니다."),
+    NOT_FOUND_ROUTINE_COMPLETION("RC002", HttpStatus.NOT_FOUND, "루틴 완료 여부 데이터를 찾을 수 없습니다."),
 
     // 온보딩 관련 에러 코드
     NOT_FOUND_RECOMMENDED_ROUTINE("ON000", HttpStatus.NOT_FOUND, "조건에 맞는 추천 루틴을 찾을 수 없습니다."),

--- a/src/main/java/bitnagil/bitnagil_backend/routine/controller/RoutineController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/controller/RoutineController.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
+import bitnagil.bitnagil_backend.routine.request.DeleteRoutineByDayRequest;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineCompletionRequest;
 import jakarta.validation.constraints.NotNull;
 
@@ -55,6 +56,17 @@ public class RoutineController implements RoutineSpec {
     @DeleteMapping("/{routineId}")
     public CustomResponseDto<Object> deleteRoutine(@CurrentUser User user, @PathVariable UUID routineId) {
         routineService.deleteRoutine(user, routineId);
+
+        return CustomResponseDto.from(null);
+    }
+
+    /*
+     * 유저가 선택한 요일(당일)만 삭제하는 API입니다.
+     */
+    @DeleteMapping("/day")
+    public CustomResponseDto<Object> deleteRoutineByDay(@CurrentUser User user,
+        @RequestBody DeleteRoutineByDayRequest deleteRoutineByDayRequest) {
+        routineService.deleteRoutineByDay(user, deleteRoutineByDayRequest);
 
         return CustomResponseDto.from(null);
     }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/controller/spec/RoutineSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/controller/spec/RoutineSpec.java
@@ -3,10 +3,14 @@ package bitnagil.bitnagil_backend.routine.controller.spec;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import org.springframework.web.bind.annotation.RequestBody;
+
+import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExamples;
 import bitnagil.bitnagil_backend.global.swagger.ApiTags;
+import bitnagil.bitnagil_backend.routine.request.DeleteRoutineByDayRequest;
 import bitnagil.bitnagil_backend.routine.request.RegisterRoutineRequest;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineRequest;
@@ -42,6 +46,16 @@ public interface RoutineSpec {
     CustomResponseDto<Object> deleteRoutine(User user, UUID routineId);
 
     @Operation(summary = "여러 루틴의 완료 여부를 갱신합니다.")
+    @ApiErrorCodeExamples({
+        ErrorCode.NOT_FOUND_ROUTINE, ErrorCode.ROUTINE_USER_NOT_MATCHED,
+        ErrorCode.NOT_FOUND_SUB_ROUTINE, ErrorCode.SUB_ROUTINE_USER_NOT_MATCHED,
+        ErrorCode.NOT_FOUND_CHANGED_ROUTINE, ErrorCode.CHANGED_ROUTINE_USER_NOT_MATCHED,
+        ErrorCode.NOT_FOUND_CHANGED_SUB_ROUTINE, ErrorCode.CHANGED_SUB_ROUTINE_USER_NOT_MATCHED
+    })
     CustomResponseDto<Object> updateRoutineCompletionStatus(User user,
         UpdateRoutineCompletionRequest updateRoutineCompletionRequest);
+
+    @Operation(summary = "선택한 요일(당일)만 루틴을 삭제합니다.")
+    @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_ROUTINE, ErrorCode.ROUTINE_USER_NOT_MATCHED})
+    CustomResponseDto<Object> deleteRoutineByDay(User user, DeleteRoutineByDayRequest deleteRoutineByDayRequest);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineCompletionRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineCompletionRepository.java
@@ -1,5 +1,6 @@
 package bitnagil.bitnagil_backend.routine.repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +14,7 @@ public interface RoutineCompletionRepository extends JpaRepository<RoutineComple
 
     Optional<RoutineCompletion> findByRoutineIdAndRoutineHistorySeqAndRoutineType(
         UUID routineId, Long routineHistorySeq, RoutineType routineType);
+
+    Optional<RoutineCompletion> findByPerformedDateAndRoutineIdAndRoutineHistorySeqAndRoutineType(
+        LocalDate performedDate, UUID routineId, Long routineHistorySeq, RoutineType routineType);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineCompletionRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/repository/RoutineCompletionRepository.java
@@ -6,11 +6,10 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import bitnagil.bitnagil_backend.global.entity.HistoryPk;
 import bitnagil.bitnagil_backend.routine.domain.RoutineCompletion;
 import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 
-public interface RoutineCompletionRepository extends JpaRepository<RoutineCompletion, HistoryPk> {
+public interface RoutineCompletionRepository extends JpaRepository<RoutineCompletion, Long> {
 
     RoutineCompletion findByRoutineIdAndRoutineHistorySeqAndRoutineType(
         UUID routineId, Long routineHistorySeq, RoutineType routineType);

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/DeleteRoutineByDayRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/DeleteRoutineByDayRequest.java
@@ -1,6 +1,7 @@
 package bitnagil.bitnagil_backend.routine.request;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,17 +14,29 @@ import lombok.NoArgsConstructor;
 @Schema(description = "선택한 요일(당일)만 루틴 삭제 DTO")
 public class DeleteRoutineByDayRequest {
 
-    @Schema(description = "삭제할 루틴 수행 날짜입니다.",
-            example = "2025-07-13",
-            required = true)
-    @NotNull
-    private LocalDate performedDate;
+    @Schema(description = "루틴완료 여부 ID입니다. 해당 값이 없는 경우에는 null로 보내주세요.",
+            example = "1")
+    private Long routineCompletionId;
 
     @Schema(description = "루틴의 ID 값입니다.",
             example = "4fa85f64-5717-4562-b3fc-2c963f66afa6",
             required = true)
     @NotNull
     private UUID routineId;
+
+    @Schema(description = "세부루틴 완료 여부 정보를 담은 리스트입니다.",
+            example = "["
+                + "{\"routineCompletionId\": 3, \"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\"},"
+                + "{\"routineCompletionId\": null, \"subRoutineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\"},"
+                + "{\"routineCompletionId\": 8, \"subRoutineId\": \"3e1e63bb-1e24-4e88-93e2-8ccd82215e08\"}"
+                + "]")
+    private List<SubRoutineInfoForDelete> subRoutineInfosForDelete;
+
+    @Schema(description = "삭제할 루틴 수행 날짜입니다.",
+            example = "2025-07-13",
+            required = true)
+    @NotNull
+    private LocalDate performedDate;
 
     @Schema(description = "루틴의 이력순번 값입니다.",
             example = "2",

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/DeleteRoutineByDayRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/DeleteRoutineByDayRequest.java
@@ -1,0 +1,33 @@
+package bitnagil.bitnagil_backend.routine.request;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "선택한 요일(당일)만 루틴 삭제 DTO")
+public class DeleteRoutineByDayRequest {
+
+    @Schema(description = "삭제할 루틴 수행 날짜입니다.",
+            example = "2025-07-13",
+            required = true)
+    @NotNull
+    private LocalDate performedDate;
+
+    @Schema(description = "루틴의 ID 값입니다.",
+            example = "4fa85f64-5717-4562-b3fc-2c963f66afa6",
+            required = true)
+    @NotNull
+    private UUID routineId;
+
+    @Schema(description = "루틴의 이력순번 값입니다.",
+            example = "2",
+            required = true)
+    @NotNull
+    private Long historySeq;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/SubRoutineInfoForDelete.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/SubRoutineInfoForDelete.java
@@ -1,0 +1,25 @@
+package bitnagil.bitnagil_backend.routine.request;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 선택한 요일(당일)만 삭제 API 요청 시 필요한 서브 루틴 완료에 대한 정보를 관리하는 클래스입니다.
+ */
+@Getter
+@NoArgsConstructor
+public class SubRoutineInfoForDelete {
+
+    @Schema(description = "세부루틴 완료 여부 ID입니다. 해당 값이 없는 경우에는 null로 보내주세요.")
+    private Long routineCompletionId;
+
+    @Schema(description = "서브 루틴의 ID 값입니다.",
+        example = "4fa85f64-5717-4562-b3fc-2c963f66afa6",
+        required = true)
+    @NotNull
+    private UUID subRoutineId;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/UpdateRoutineCompletionRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/UpdateRoutineCompletionRequest.java
@@ -26,13 +26,13 @@ public class UpdateRoutineCompletionRequest {
             "\"routineType\": \"CHANGED_SUB_ROUTINE\", " +
             "\"routineId\": \"4fa85f64-5717-4562-b3fc-2c963f66afa6\", " +
             "\"historySeq\": 2, " +
-            "\"isCompleted\": false" +
+            "\"completeYn\": false" +
             "}, " +
             "{" +
             "\"routineType\": \"ROUTINE\", " +
             "\"routineId\": \"123e4567-e89b-12d3-a456-426614174000\", " +
             "\"historySeq\": 1, " +
-            "\"isCompleted\": true" +
+            "\"completeYn\": true" +
             "}" +
             "]",
         required = true

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -18,6 +18,7 @@ import bitnagil.bitnagil_backend.changedRoutine.repository.ChangedSubRoutineRepo
 import bitnagil.bitnagil_backend.routine.domain.RoutineCompletion;
 import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 import bitnagil.bitnagil_backend.routine.repository.RoutineCompletionRepository;
+import bitnagil.bitnagil_backend.routine.request.DeleteRoutineByDayRequest;
 import bitnagil.bitnagil_backend.routine.request.RoutineCompletionInfo;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routine.response.RoutineSearchResponse;
@@ -144,6 +145,57 @@ public class RoutineService {
 
     }
 
+    // 유저가 선택한 요일(당일)만 루틴, 서브 루틴을 삭제하는 메서드
+    @Transactional
+    public void deleteRoutineByDay(User user, DeleteRoutineByDayRequest request) {
+        LocalDateTime now = LocalDateTime.now();
+
+        Routine routine = validateRoutineOwnership(request.getRoutineId(), user, now);
+
+        // 변경 루틴으로 전환
+        ChangedRoutine changedRoutineForDelete = ChangedRoutine.builder()
+            .changedRoutinePk(new HistoryPk(UUID.randomUUID(), 1L))
+            .changedRoutineName(routine.getName())
+            .changedExecutionTime(routine.getExecutionTime())
+            .originalRoutineDate(request.getPerformedDate())
+            .changedRoutineDate(request.getPerformedDate())
+            .historyStartDateTime(now)
+            .historyEndDateTime(TimeUtils.END_DATE_TIME)
+            .changedDivCode(ChangedDivCode.TODAY_DELETE)
+            .userId(routine.getUserId())
+            .routineId(routine.getRoutinePk().getId())
+            .build();
+
+        changedRoutineRepository.save(changedRoutineForDelete);
+
+        // 루틴, performedDate에 해당하는 완료 여부 데이터 삭제
+        routineCompletionRepository.findByPerformedDateAndRoutineIdAndRoutineHistorySeqAndRoutineType(
+            request.getPerformedDate(), request.getRoutineId(), request.getHistorySeq(), RoutineType.ROUTINE)
+            .ifPresent(routineCompletionRepository::delete);
+
+        // 변경 서브루틴으로 전환
+        List<SubRoutine> subRoutines = subRoutineRepository.findByRoutineId(routine.getRoutinePk().getId());
+
+        for (SubRoutine subRoutine : subRoutines) {
+            ChangedSubRoutine changedSubRoutineForDelete = ChangedSubRoutine.builder()
+                .changedSubRoutinePk(new HistoryPk(UUID.randomUUID(), 1L))
+                .changedSubRoutineName(subRoutine.getName())
+                .historyStartDateTime(now)
+                .historyEndDateTime(TimeUtils.END_DATE_TIME)
+                .changedRoutineId(changedRoutineForDelete.getChangedRoutinePk().getId())
+                .sortOrder(subRoutine.getSortOrder())
+                .build();
+
+            changedSubRoutineRepository.save(changedSubRoutineForDelete);
+
+            // 서브루틴, performedDate에 해당하는 완료 여부 데이터 삭제
+            routineCompletionRepository.findByPerformedDateAndRoutineIdAndRoutineHistorySeqAndRoutineType(
+                request.getPerformedDate(), subRoutine.getSubRoutinePk().getId(),
+                subRoutine.getSubRoutinePk().getHistorySeq(), RoutineType.SUB_ROUTINE)
+                .ifPresent(routineCompletionRepository::delete);
+        }
+    }
+
     /**
      * 회원이 보유한 특정 기간(start_date, end_date)의 루틴을 조회하는 메서드입니다.
      */
@@ -208,6 +260,7 @@ public class RoutineService {
                 SubRoutine subRoutine = subRoutineRepository.findBySubRoutinePk(historyPk).orElseThrow(
                     () -> new CustomException(ErrorCode.NOT_FOUND_SUB_ROUTINE));
 
+                // 추후 성능 이슈가 발생할 수 있는 부분
                 List<Routine> routines = routineRepository.findByRoutinePk_Id(subRoutine.getRoutineId());
 
                 if (!user.getUserPk().getId().equals(routines.get(0).getUserId())) {

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.time.LocalTime;
 
 import bitnagil.bitnagil_backend.changedRoutine.domain.ChangedRoutine;
 import bitnagil.bitnagil_backend.changedRoutine.domain.ChangedSubRoutine;
@@ -20,6 +19,7 @@ import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 import bitnagil.bitnagil_backend.routine.repository.RoutineCompletionRepository;
 import bitnagil.bitnagil_backend.routine.request.DeleteRoutineByDayRequest;
 import bitnagil.bitnagil_backend.routine.request.RoutineCompletionInfo;
+import bitnagil.bitnagil_backend.routine.request.SubRoutineInfoForDelete;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routine.response.RoutineSearchResponse;
 import bitnagil.bitnagil_backend.routine.response.RoutineSearchResultDto;
@@ -169,9 +169,7 @@ public class RoutineService {
         changedRoutineRepository.save(changedRoutineForDelete);
 
         // 루틴, performedDate에 해당하는 완료 여부 데이터 삭제
-        routineCompletionRepository.findByPerformedDateAndRoutineIdAndRoutineHistorySeqAndRoutineType(
-            request.getPerformedDate(), request.getRoutineId(), request.getHistorySeq(), RoutineType.ROUTINE)
-            .ifPresent(routineCompletionRepository::delete);
+        deleteRoutineCompletionIfRoutineIdMatches(request.getRoutineCompletionId(), request.getRoutineId());
 
         // 변경 서브루틴으로 전환
         List<SubRoutine> subRoutines = subRoutineRepository.findByRoutineId(routine.getRoutinePk().getId());
@@ -187,12 +185,11 @@ public class RoutineService {
                 .build();
 
             changedSubRoutineRepository.save(changedSubRoutineForDelete);
+        }
 
-            // 서브루틴, performedDate에 해당하는 완료 여부 데이터 삭제
-            routineCompletionRepository.findByPerformedDateAndRoutineIdAndRoutineHistorySeqAndRoutineType(
-                request.getPerformedDate(), subRoutine.getSubRoutinePk().getId(),
-                subRoutine.getSubRoutinePk().getHistorySeq(), RoutineType.SUB_ROUTINE)
-                .ifPresent(routineCompletionRepository::delete);
+        // 서브루틴, performedDate에 해당하는 완료 여부 데이터 삭제
+        for (SubRoutineInfoForDelete info : request.getSubRoutineInfosForDelete()) {
+            deleteRoutineCompletionIfRoutineIdMatches(info.getRoutineCompletionId(), info.getSubRoutineId());
         }
     }
 
@@ -239,6 +236,25 @@ public class RoutineService {
                 routineCompletionRepository.save(newRoutineCompletion);
             }
         }
+    }
+
+    // 루틴, performedDate에 해당하는 완료 여부 데이터 삭제
+    private void deleteRoutineCompletionIfRoutineIdMatches(Long routineCompletionId, UUID routineId) {
+
+        // 완료 여부가 생성되지 않은 루틴일 경우
+        if (routineCompletionId == null) {
+            return;
+        }
+
+        RoutineCompletion routineCompletion = routineCompletionRepository.findById(routineCompletionId).orElseThrow(
+            () -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE_COMPLETION)
+        );
+
+        if (!routineCompletion.getRoutineId().equals(routineId)) {
+            throw new CustomException(ErrorCode.ROUTINE_ID_MISMATCH);
+        }
+
+        routineCompletionRepository.delete(routineCompletion);
     }
 
     // 각 타입의 루틴이 실제로 존재하는 루틴인지, 실제로 유저가 가지고 있는 루틴인지 검증하는 메서드

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
@@ -4,10 +4,11 @@ import bitnagil.bitnagil_backend.user.request.UserAgreementsRequest;
 import bitnagil.bitnagil_backend.user.request.UserLoginRequest;
 import org.springframework.web.bind.annotation.*;
 
-import bitnagil.bitnagil_backend.auth.jwt.TokenResponse;
+import bitnagil.bitnagil_backend.user.response.UserLoginResponse;
 import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.user.controller.spec.UserAuthSpec;
 import bitnagil.bitnagil_backend.user.domain.User;
+import bitnagil.bitnagil_backend.user.response.UserReissueResponse;
 import bitnagil.bitnagil_backend.user.service.UserAuthService;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -19,16 +20,16 @@ public class UserAuthController implements UserAuthSpec {
     private final UserAuthService userAuthService;
 
     @PostMapping("/login")
-    public CustomResponseDto<TokenResponse> login(
+    public CustomResponseDto<UserLoginResponse> login(
             @RequestBody UserLoginRequest userLoginRequest,
             @RequestHeader("SocialAccessToken") String socialAccessToken) {
 
-        TokenResponse tokenResponse = userAuthService.socialLogin(
+        UserLoginResponse userLoginResponse = userAuthService.socialLogin(
             userLoginRequest.getSocialType(),
             userLoginRequest.getNickname(),
             socialAccessToken);
 
-        return CustomResponseDto.from(tokenResponse);
+        return CustomResponseDto.from(userLoginResponse);
     }
 
     @PostMapping("/logout")
@@ -39,10 +40,10 @@ public class UserAuthController implements UserAuthSpec {
     }
 
     @PostMapping("/token/reissue")
-    public CustomResponseDto<TokenResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
-        TokenResponse tokenResponse = userAuthService.reissueToken(refreshToken);
+    public CustomResponseDto<UserReissueResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        UserReissueResponse userReissueResponse = userAuthService.reissueToken(refreshToken);
 
-        return CustomResponseDto.from(tokenResponse);
+        return CustomResponseDto.from(userReissueResponse);
     }
 
     @PostMapping("/withdrawal")

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
@@ -40,7 +40,7 @@ public class UserAuthController implements UserAuthSpec {
     }
 
     @PostMapping("/token/reissue")
-    public CustomResponseDto<UserReissueResponse> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
+    public CustomResponseDto<UserReissueResponse> reissueToken(@RequestHeader("Refresh-Token") String refreshToken) {
         UserReissueResponse userReissueResponse = userAuthService.reissueToken(refreshToken);
 
         return CustomResponseDto.from(userReissueResponse);

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
@@ -3,10 +3,9 @@ package bitnagil.bitnagil_backend.user.controller.spec;
 import bitnagil.bitnagil_backend.user.request.UserAgreementsRequest;
 import bitnagil.bitnagil_backend.user.request.UserLoginRequest;
 
-import bitnagil.bitnagil_backend.auth.jwt.TokenResponse;
+import bitnagil.bitnagil_backend.user.response.UserLoginResponse;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
-import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExample;
 import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExamples;
 import bitnagil.bitnagil_backend.global.swagger.ApiTags;
 import bitnagil.bitnagil_backend.user.domain.User;
@@ -31,7 +30,7 @@ public interface UserAuthSpec {
             @Parameter(name = "SocialAccessToken", description = "소셜로그인 플랫폼에서 발급해준 access token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", in = ParameterIn.HEADER),
     })
-    CustomResponseDto<TokenResponse> login(UserLoginRequest userLoginRequest,
+    CustomResponseDto<UserLoginResponse> login(UserLoginRequest userLoginRequest,
                                            String socialAccessToken);
 
 
@@ -50,7 +49,7 @@ public interface UserAuthSpec {
             @Parameter(name = "Refresh-Token", description = "서버에서 발급해준 refresh token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", in = ParameterIn.HEADER)
     })
-    CustomResponseDto<TokenResponse> refreshToken(String refreshToken);
+    CustomResponseDto<UserLoginResponse> refreshToken(String refreshToken);
 
 
     @Operation(summary = "소셜로그인으로 연결된 유저가 회원탈퇴합니다. 반환 정보는 없습니다.")

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
@@ -9,6 +9,7 @@ import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExamples;
 import bitnagil.bitnagil_backend.global.swagger.ApiTags;
 import bitnagil.bitnagil_backend.user.domain.User;
+import bitnagil.bitnagil_backend.user.response.UserReissueResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -49,7 +50,7 @@ public interface UserAuthSpec {
             @Parameter(name = "Refresh-Token", description = "서버에서 발급해준 refresh token 입니다.(Bearer를 붙히지 않습니다.)", required = true,
             example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", in = ParameterIn.HEADER)
     })
-    CustomResponseDto<UserLoginResponse> refreshToken(String refreshToken);
+    CustomResponseDto<UserReissueResponse> reissueToken(String refreshToken);
 
 
     @Operation(summary = "소셜로그인으로 연결된 유저가 회원탈퇴합니다. 반환 정보는 없습니다.")

--- a/src/main/java/bitnagil/bitnagil_backend/user/domain/User.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/domain/User.java
@@ -91,4 +91,8 @@ public class User extends BaseTimeEntity {
     public void updateHistoryEndDateTime(LocalDateTime endDateTime) {
         this.historyEndDateTime = endDateTime;
     }
+
+    public void changeRoleToWithdrawn() {
+        this.role = Role.WITHDRAWN;
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/user/repository/UserRepository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/repository/UserRepository.java
@@ -14,8 +14,6 @@ import bitnagil.bitnagil_backend.user.domain.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, HistoryPk> {
 
-    Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
-
     // socialType, socialId 기반으로 유저 이력들 특정 후, 이력 시작일시 및 종료일시를 활용해서 현재시간 기준으로 유효한 유저 식별
     Optional<User> findBySocialTypeAndSocialIdAndHistoryStartDateTimeLessThanAndHistoryEndDateTimeGreaterThanEqual(
         SocialType socialType, String socialId, LocalDateTime historyStartDateBound, LocalDateTime historyEndDateBound);

--- a/src/main/java/bitnagil/bitnagil_backend/user/response/UserLoginResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/response/UserLoginResponse.java
@@ -1,5 +1,6 @@
-package bitnagil.bitnagil_backend.auth.jwt;
+package bitnagil.bitnagil_backend.user.response;
 
+import bitnagil.bitnagil_backend.auth.jwt.Token;
 import bitnagil.bitnagil_backend.enums.Role;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
@@ -12,7 +13,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Builder
-public class TokenResponse {
+public class UserLoginResponse {
     @NotEmpty
     private String accessToken;
 
@@ -22,15 +23,8 @@ public class TokenResponse {
     @NotEmpty
     private Role role;
 
-    public static TokenResponse of(Token token) {
-        return TokenResponse.builder()
-            .accessToken(token.getAccessToken())
-            .refreshToken(token.getRefreshToken())
-            .build();
-    }
-
-    public static TokenResponse of(Token token, Role role) {
-        return TokenResponse.builder()
+    public static UserLoginResponse of(Token token, Role role) {
+        return UserLoginResponse.builder()
                 .accessToken(token.getAccessToken())
                 .refreshToken(token.getRefreshToken())
                 .role(role)

--- a/src/main/java/bitnagil/bitnagil_backend/user/response/UserReissueResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/response/UserReissueResponse.java
@@ -1,0 +1,26 @@
+package bitnagil.bitnagil_backend.user.response;
+
+import bitnagil.bitnagil_backend.auth.jwt.Token;
+import bitnagil.bitnagil_backend.enums.Role;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserReissueResponse {
+    @NotEmpty
+    private String accessToken;
+
+    @NotEmpty
+    private String refreshToken;
+
+    public static UserReissueResponse of(Token token) {
+        return UserReissueResponse.builder()
+            .accessToken(token.getAccessToken())
+            .refreshToken(token.getRefreshToken())
+            .build();
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -91,12 +91,17 @@ public class UserAuthService {
     public void withdrawal(User user) {
         LocalDateTime now = LocalDateTime.now();
 
-        invalidateToken(user);
+        // 변경 감지를 위해 영속 상태로 설정
+        User persistentUser = userRepository.findByUserPk(user.getUserPk()).orElseThrow(
+            () -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
-        // 기존 유저의 이력 종료일시를 갱신
-        user.updateHistoryEndDateTime(now);
+        invalidateToken(persistentUser);
 
-        unlinkFromSocial(user);
+        // 기존 유저의 이력 종료일시를 갱신 및 role 변경
+        persistentUser.updateHistoryEndDateTime(now);
+        persistentUser.changeRoleToWithdrawn();
+
+        unlinkFromSocial(persistentUser);
     }
 
     // 약관 동의 - 회원의 ROLE을 USER로 업데이트

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -21,10 +21,11 @@ import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
 import bitnagil.bitnagil_backend.user.repository.UserRepository;
 import bitnagil.bitnagil_backend.enums.SocialType;
-import bitnagil.bitnagil_backend.auth.jwt.TokenResponse;
+import bitnagil.bitnagil_backend.user.response.UserLoginResponse;
 import bitnagil.bitnagil_backend.user.domain.User;
 import bitnagil.bitnagil_backend.enums.Role;
 import bitnagil.bitnagil_backend.user.domain.UserAuthInfo;
+import bitnagil.bitnagil_backend.user.response.UserReissueResponse;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -42,7 +43,7 @@ public class UserAuthService {
 
     // 소셜 로그인을 통해 로그인 혹은 회원가입을 진행
     @Transactional
-    public TokenResponse socialLogin(SocialType socialType, String nickname, String socialAccessToken) {
+    public UserLoginResponse socialLogin(SocialType socialType, String nickname, String socialAccessToken) {
 
         UserAuthInfo userAuthInfo = getUserAuthInfo(socialType, socialAccessToken);
 
@@ -50,12 +51,12 @@ public class UserAuthService {
 
         Token token = jwtUtil.generateToken(user.getUserPk());
 
-        return TokenResponse.of(token, user.getRole());
+        return UserLoginResponse.of(token, user.getRole());
     }
 
     // refreshToken으로 accessToken 재발행
     @Transactional
-    public TokenResponse reissueToken(String refreshToken) {
+    public UserReissueResponse reissueToken(String refreshToken) {
 
         if (!jwtUtil.validateToken(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
@@ -72,7 +73,7 @@ public class UserAuthService {
 
         Token token = jwtUtil.generateToken(user.getUserPk());
 
-        return TokenResponse.of(token);
+        return UserReissueResponse.of(token);
     }
 
     // refreshToken 삭제 및 카카오 토큰 무효화


### PR DESCRIPTION
## 작업 내역
- 선택한 요일(당일)만 루틴을 삭제하는 API 추가
       - 이때 변경 루틴, 변경 서브루틴에 해당 루틴 정보를 추가하고, 기존 수행 날짜에 삭제된 루틴에 대한 완료 여부 데이터 또한 삭제합니다.
- reissue API에서 response에 role 필드를 삭제하기 위해 기존 TokenResponse를 UserLoginResponse, UserReissueResponse로 분리
- JWT 인증 실패 시 401 에러 반환 response에서 data 필드 삭제
- 회원 탈퇴 시 비영속 상태 문제 해결 및 회원 탈퇴 시 해당 유저 role을 `WITHDRAWN`으로 설정 (재가입 시에 historyEndDateTime이외에 기존 탈퇴 유저와 재가입 유저를 식별하기 위해 추가)
- 로컬 테스트 완료

## 고민한 사항
없습니다.

## 리뷰 요청사항
- 작업 내역이 많지 않아서 작업 내역 기반으로 한번 훑어주시면 됩니다~!