### PR TITLE
[T3-126] 루틴 조회 시 불필요한 응답값 제거

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/routine/response/RoutineSearchResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/response/RoutineSearchResponse.java
@@ -17,8 +17,4 @@ import java.util.Map;
 public class RoutineSearchResponse {
     @Schema(description = "날짜(LocalDate: 2025-07-01)와 같은 형태를 key로 가지는 루틴 목록 Map입니다. Swagger에서는 additionalProp1처럼 보일 수 있습니다.")
     private Map<LocalDate, List<RoutineSearchResultDto>> routines; // 날짜별 루틴 목록
-    @Schema(description = "회원명", example = "홍길동")
-    private String nickname; // 회원명
-    @Schema(description = "감정 구슬 타입", example = "CALM")
-    private EmotionMarbleType emotionMarbleType; // 감정 구슬 타입
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -269,13 +269,8 @@ public class RoutineService {
                     -> a.getExecutionTime().compareTo(b.getExecutionTime()));
         }
 
-        // 감정구슬 조회
-        EmotionMarble emotionMarble = emotionMarbleRepository.findByUserIdAndDateIs(user.getUserPk().getId(), LocalDate.now());
-
         return RoutineSearchResponse.builder()
                 .routines(routinesByDateResponse)
-                .emotionMarbleType(emotionMarble == null ? null : emotionMarble.getEmotionMarbleType())
-                .nickname(user.getNickname())
                 .build();
     }
 


### PR DESCRIPTION
## 작업 내역
-  기존 응답 객체(`RoutineSearchResponse`)에서 `nickname`과 `emotionType` 제거
## 고민한 사항

## 리뷰 요청사항