### PR TITLE
[T3-125] 유저 닉네임 조회, 감정 구슬 조회 API

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/EmotionMarbleController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/EmotionMarbleController.java
@@ -8,9 +8,12 @@ import bitnagil.bitnagil_backend.emotionMarble.service.EmotionMarbleService;
 import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.user.domain.User;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -27,7 +30,19 @@ public class EmotionMarbleController implements EmotionMarbleSpec {
 
     // 감정구슬 등록 API
     @PostMapping("")
-    public CustomResponseDto<RegisterEmotionMarbleResponse> registryEmotionMarble(@CurrentUser User user, @RequestBody RegisterEmotionMarbleRequest request) {
+    public CustomResponseDto<RegisterEmotionMarbleResponse> registryEmotionMarble(
+        @CurrentUser User user,
+        @RequestBody RegisterEmotionMarbleRequest request) {
+
         return CustomResponseDto.from(emotionMarbleService.registryEmotionMarble(user, request));
+    }
+
+    // 당일의 유저가 선택한 감정 구슬 조회 API
+    @GetMapping("/me")
+    public CustomResponseDto<EmotionMarbleTypeResponse> getEmotionMarbleForHome(
+        @CurrentUser User user,
+        @RequestParam @NotNull LocalDate searchDate) {
+
+        return CustomResponseDto.from(emotionMarbleService.getEmotionMarbleForHome(user, searchDate));
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/spec/EmotionMarbleSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/spec/EmotionMarbleSpec.java
@@ -3,15 +3,23 @@ package bitnagil.bitnagil_backend.emotionMarble.controller.spec;
 import bitnagil.bitnagil_backend.emotionMarble.request.RegisterEmotionMarbleRequest;
 import bitnagil.bitnagil_backend.emotionMarble.response.EmotionMarbleTypeResponse;
 import bitnagil.bitnagil_backend.emotionMarble.response.RegisterEmotionMarbleResponse;
+import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExamples;
 import bitnagil.bitnagil_backend.global.swagger.ApiTags;
 import bitnagil.bitnagil_backend.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
 import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = ApiTags.EMOTION_MARBLE)
 public interface EmotionMarbleSpec {
@@ -21,5 +29,14 @@ public interface EmotionMarbleSpec {
 
     @Operation(summary = "감정 구슬을 등록합니다. 감정 구슬에 따른 추천 루틴을 응답합니다.")
     @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_RECOMMENDED_ROUTINE})
-    public CustomResponseDto<RegisterEmotionMarbleResponse> registryEmotionMarble(User user, RegisterEmotionMarbleRequest request);
+    public CustomResponseDto<RegisterEmotionMarbleResponse> registryEmotionMarble(
+        User user, RegisterEmotionMarbleRequest request);
+
+    @Operation(summary = "검색 날짜 기준으로 대한 유저의 감정구슬 정보를 조회합니다.")
+    @Parameters({
+        @Parameter(name = "searchDate", description = "감정 구슬 조회 날짜", required = true, example = "2025-07-01")
+    })
+    CustomResponseDto<EmotionMarbleTypeResponse> getEmotionMarbleForHome(
+        @CurrentUser User user,
+        @RequestParam @NotNull LocalDate searchDate);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/response/EmotionMarbleTypeResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/response/EmotionMarbleTypeResponse.java
@@ -17,6 +17,6 @@ public class EmotionMarbleTypeResponse {
     @Schema(description = "감정 구슬 명칭", example = "평온함")
     private String emotionMarbleName;
 
-    @Schema(description = "감정 구슬 이미지 URL", example = "https://example.com/image/calm.png")
+    @Schema(description = "감정 구슬 이미지 URL (홈/구슬 선택 화면 이미지 다름)", example = "https://example.com/image/calm.png")
     private String imageUrl;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/service/EmotionMarbleMapper.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/service/EmotionMarbleMapper.java
@@ -1,5 +1,6 @@
 package bitnagil.bitnagil_backend.emotionMarble.service;
 
+import bitnagil.bitnagil_backend.emotionMarble.domain.EmotionMarble;
 import bitnagil.bitnagil_backend.emotionMarble.domain.enums.EmotionMarbleType;
 import bitnagil.bitnagil_backend.emotionMarble.response.EmotionMarbleTypeResponse;
 import org.springframework.stereotype.Component;
@@ -18,5 +19,13 @@ public class EmotionMarbleMapper {
                 .emotionMarbleType(emotionMarbleType)
                 .imageUrl(emotionMarbleType.getMarbleImageUrl())
                 .build();
+    }
+
+    public EmotionMarbleTypeResponse toEmotionMarbleTypeResponse(EmotionMarble emotionMarble) {
+        return EmotionMarbleTypeResponse.builder()
+            .emotionMarbleType(emotionMarble == null ? null : emotionMarble.getEmotionMarbleType())
+            .emotionMarbleName(emotionMarble == null ? null : emotionMarble.getEmotionMarbleType().getDescription())
+            .imageUrl(emotionMarble == null ? null :emotionMarble.getEmotionMarbleType().getHomeMarbleImageUrl())
+            .build();
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/service/EmotionMarbleService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/service/EmotionMarbleService.java
@@ -70,5 +70,14 @@ public class EmotionMarbleService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
+    public EmotionMarbleTypeResponse getEmotionMarbleForHome(User user, LocalDate searchDate) {
+        EmotionMarble emotionMarble = emotionMarbleRepository.findByUserIdAndDateIs(
+            user.getUserPk().getId(), searchDate);
+
+        return emotionMarbleMapper.toEmotionMarbleTypeResponse(emotionMarble);
+    }
+
+
 
 }

--- a/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
@@ -21,6 +21,7 @@ import bitnagil.bitnagil_backend.recommendedRoutine.repository.RecommendedSubRou
 import bitnagil.bitnagil_backend.recommendedRoutine.service.RecommendedRoutineManager;
 import bitnagil.bitnagil_backend.user.domain.User;
 import bitnagil.bitnagil_backend.user.repository.UserRepository;
+import bitnagil.bitnagil_backend.user.service.UserManager;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -46,6 +47,7 @@ public class OnboardingService {
 
     private final RecommendedRoutineManager recommendedRoutineManager;
     private final ChangedRoutineFactory changedRoutineFactory;
+    private final UserManager userManager;
 
     /**
      * 유저와 매칭되는 온보딩 결과를 설정하고, 리턴하는 메서드
@@ -62,9 +64,8 @@ public class OnboardingService {
         );
 
         // 회원은 온보딩과의 연관관계를 설정한다.
-        user = userRepository.findByUserPk(user.getUserPk()).orElseThrow(
-            () -> new CustomException(ErrorCode.NOT_FOUND_USER));
-        user.updateOnboarding(onboarding);
+        User persistedUser = userManager.getPersistedUser(user);
+        persistedUser.updateOnboarding(onboarding);
 
         // 온보딩의 CASE를 통해 추천루틴을 조회한다.
         List<RecommendedRoutineDto> recommendedRoutineDtoList =

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineManager.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineManager.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
@@ -15,7 +16,10 @@ import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedRoutineD
 import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedSubRoutineSearchResult;
 import lombok.RequiredArgsConstructor;
 
-@Component
+/**
+ * 외부에서 사용되는 추천 루틴에 대한 공통 로직을 관리하는 클래스입니다.
+ */
+@Service
 @RequiredArgsConstructor
 public class RecommendedRoutineManager {
 

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineMapper.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineMapper.java
@@ -1,12 +1,16 @@
 package bitnagil.bitnagil_backend.recommendedRoutine.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
+import bitnagil.bitnagil_backend.emotionMarble.domain.EmotionMarble;
 import bitnagil.bitnagil_backend.recommendedRoutine.domain.RecommendedRoutine;
 import bitnagil.bitnagil_backend.recommendedRoutine.domain.RecommendedSubRoutine;
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.enums.RecommendedRoutineType;
 import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedRoutineDto;
+import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedRoutineSearchResponse;
 import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedRoutineSearchResult;
 import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedSubRoutineSearchResult;
 
@@ -49,6 +53,16 @@ public class RecommendedRoutineMapper {
         return RecommendedSubRoutineSearchResult.builder()
             .recommendedSubRoutineId(recommendedSubRoutine.getRecommendedSubRoutineId())
             .recommendedSubRoutineName(recommendedSubRoutine.getSubRoutineName())
+            .build();
+    }
+
+    // 추천 카테고리 별 루틴, 서브루틴을 반환하는 DTO로 변환
+    public RecommendedRoutineSearchResponse toRecommendedRoutineSearchResponse(
+        Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> response, EmotionMarble emotionMarble) {
+
+        return RecommendedRoutineSearchResponse.builder()
+            .recommendedRoutines(response)
+            .emotionMarbleType(emotionMarble == null ? null : emotionMarble.getEmotionMarbleType()) // 감정 구슬 타입 설정
             .build();
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineService.java
@@ -15,7 +15,7 @@ import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedRoutineS
 import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedRoutineSearchResult;
 import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedSubRoutineSearchResult;
 import bitnagil.bitnagil_backend.user.domain.User;
-import bitnagil.bitnagil_backend.user.repository.UserRepository;
+import bitnagil.bitnagil_backend.user.service.UserManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,9 +38,9 @@ public class RecommendedRoutineService {
     private final RecommendedRoutineRepository recommendedRoutineRepository;
     private final RecommendedSubRoutineRepository recommendedSubRoutineRepository;
     private final EmotionMarbleRepository emotionMarbleRepository;
-    private final UserRepository userRepository;
 
     private final RecommendedRoutineMapper recommendedRoutineMapper;
+    private final UserManager userManager;
 
     /**
      * 추천 카테고리별 루틴, 서브루틴을 조회
@@ -56,11 +56,10 @@ public class RecommendedRoutineService {
         response.put(RecommendedRoutineType.PERSONALIZED, new ArrayList<>()); // 맞춤 루틴은 미리 초기화 한다.(감정구슬, 온보딩 결과를 넣기 위해)
 
         // 영속성 객체에 user를 저장하기 위해 user를 조회
-        user = userRepository.findByUserPk(user.getUserPk())
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        User persistedUser = userManager.getPersistedUser(user);
 
         // 맞춤 추천(감정구슬 + 온보딩)을 조회하고 response에 추가
-        EmotionMarble emotionMarble = addPersonalizedRecommendedRoutine(user, nowDate, response);
+        EmotionMarble emotionMarble = addPersonalizedRecommendedRoutine(persistedUser, nowDate, response);
 
         // 맞춤추천 이외의 카테고리에 대한 추천 루틴을 response 추가
         addCategoryRecommendedRoutines(response);

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineService.java
@@ -65,10 +65,7 @@ public class RecommendedRoutineService {
         // 맞춤추천 이외의 카테고리에 대한 추천 루틴을 response 추가
         addCategoryRecommendedRoutines(response);
 
-        return RecommendedRoutineSearchResponse.builder()
-                .recommendedRoutines(response)
-                .emotionMarbleType(emotionMarble == null ? null : emotionMarble.getEmotionMarbleType()) // 감정 구슬 타입 설정
-                .build();
+        return recommendedRoutineMapper.toRecommendedRoutineSearchResponse(response, emotionMarble);
     }
 
     /**
@@ -108,7 +105,7 @@ public class RecommendedRoutineService {
         }
     }
 
-    private  EmotionMarble addPersonalizedRecommendedRoutine(User user, LocalDate nowDate,
+    private EmotionMarble addPersonalizedRecommendedRoutine(User user, LocalDate nowDate,
         Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> response) {
         // 감정구슬(당일에 감정구슬을 선택한 경우만 조회)
         EmotionMarble emotionMarble = emotionMarbleRepository.findByUserIdAndDateIs(user.getUserPk().getId(), nowDate);

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package bitnagil.bitnagil_backend.user.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
+import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
+import bitnagil.bitnagil_backend.user.controller.spec.UserSpec;
+import bitnagil.bitnagil_backend.user.domain.User;
+import bitnagil.bitnagil_backend.user.response.UserInfoResponse;
+import bitnagil.bitnagil_backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/v1/users")
+public class UserController implements UserSpec {
+
+    private final UserService userService;
+
+    @GetMapping("/nickname")
+    public CustomResponseDto<UserInfoResponse> getUserInfo(@CurrentUser User user) {
+        UserInfoResponse userInfoResponse = userService.getUserInfo(user);
+
+        return CustomResponseDto.from(userInfoResponse);
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserSpec.java
@@ -1,0 +1,18 @@
+package bitnagil.bitnagil_backend.user.controller.spec;
+
+import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
+import bitnagil.bitnagil_backend.global.swagger.ApiTags;
+import bitnagil.bitnagil_backend.user.domain.User;
+import bitnagil.bitnagil_backend.user.response.UserInfoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * 유저 API 스펙 정의
+ */
+@Tag(name = ApiTags.USER)
+public interface UserSpec {
+
+    @Operation(summary = "유저 정보를 조회합니다.")
+    CustomResponseDto<UserInfoResponse> getUserInfo(User user);
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/response/UserInfoResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/response/UserInfoResponse.java
@@ -1,0 +1,18 @@
+package bitnagil.bitnagil_backend.user.response;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 유저 정보를 담는 Response 클래스입니다.
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserInfoResponse {
+
+    @NotEmpty
+    private String nickname;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -41,6 +41,8 @@ public class UserAuthService {
     private final AppleUserInfoService appleUserInfoService;
     private final KakaoUserInfoService kakaoUserInfoService;
 
+    private final UserManager userManager;
+
     // 소셜 로그인을 통해 로그인 혹은 회원가입을 진행
     @Transactional
     public UserLoginResponse socialLogin(SocialType socialType, String nickname, String socialAccessToken) {
@@ -92,24 +94,22 @@ public class UserAuthService {
         LocalDateTime now = LocalDateTime.now();
 
         // 변경 감지를 위해 영속 상태로 설정
-        User persistentUser = userRepository.findByUserPk(user.getUserPk()).orElseThrow(
-            () -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        User persistedUser = userManager.getPersistedUser(user);
 
-        invalidateToken(persistentUser);
+        invalidateToken(persistedUser);
 
         // 기존 유저의 이력 종료일시를 갱신 및 role 변경
-        persistentUser.updateHistoryEndDateTime(now);
-        persistentUser.changeRoleToWithdrawn();
+        persistedUser.updateHistoryEndDateTime(now);
+        persistedUser.changeRoleToWithdrawn();
 
-        unlinkFromSocial(persistentUser);
+        unlinkFromSocial(persistedUser);
     }
 
     // 약관 동의 - 회원의 ROLE을 USER로 업데이트
     @Transactional
     public void agreements(UserAgreementsRequest userAgreeMentsRequest, User user) {
         // 약관 동의 시 ROLE을 USER로 변경 및 동의 여부 업데이트
-        User findUser = userRepository.findByUserPk(user.getUserPk()).orElseThrow(() ->
-            new CustomException(ErrorCode.NOT_FOUND_USER));
+        User persistedUser = userManager.getPersistedUser(user);
 
         if(userAgreeMentsRequest.getAgreedToTermsOfService() == false ||
             userAgreeMentsRequest.getAgreedToPrivacyPolicy() == false ||
@@ -117,7 +117,7 @@ public class UserAuthService {
             throw new CustomException(ErrorCode.AGREEMENT_NOT_ACCEPTED);
         }
 
-        findUser.updateAgreements(userAgreeMentsRequest.getAgreedToTermsOfService(),
+        persistedUser.updateAgreements(userAgreeMentsRequest.getAgreedToTermsOfService(),
                                   userAgreeMentsRequest.getAgreedToPrivacyPolicy(),
                                   userAgreeMentsRequest.getIsOverFourteen());
     }

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserManager.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserManager.java
@@ -1,0 +1,25 @@
+package bitnagil.bitnagil_backend.user.service;
+
+import org.springframework.stereotype.Service;
+
+import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
+import bitnagil.bitnagil_backend.global.exception.CustomException;
+import bitnagil.bitnagil_backend.user.domain.User;
+import bitnagil.bitnagil_backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 외부에서 사용되는 유저에 대한 공통 로직을 관리하는 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserManager {
+
+    private final UserRepository userRepository;
+
+    // User 엔티티를 영속 상태로 변경하여 user 정보를 업데이트를 하기 위한 메서드
+    public User getPersistedUser(User user) {
+        return userRepository.findByUserPk(user.getUserPk()).orElseThrow(
+            () -> new CustomException(ErrorCode.NOT_FOUND_USER));
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserMapper.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserMapper.java
@@ -1,0 +1,19 @@
+package bitnagil.bitnagil_backend.user.service;
+
+import org.springframework.stereotype.Component;
+
+import bitnagil.bitnagil_backend.user.domain.User;
+import bitnagil.bitnagil_backend.user.response.UserInfoResponse;
+
+/*
+ * 유저 관련 DTO로 변환하는 클래스입니다.
+ */
+@Component
+public class UserMapper {
+
+    public UserInfoResponse toUserInfoResponse(User user) {
+        return UserInfoResponse.builder()
+            .nickname(user.getNickname())
+            .build();
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserService.java
@@ -1,0 +1,23 @@
+package bitnagil.bitnagil_backend.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import bitnagil.bitnagil_backend.user.domain.User;
+import bitnagil.bitnagil_backend.user.response.UserInfoResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 유저 정보를 관리하는 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserMapper userMapper;
+
+    @Transactional(readOnly = true)
+    public UserInfoResponse getUserInfo(User user) {
+        return userMapper.toUserInfoResponse(user);
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserService.java
@@ -16,7 +16,6 @@ public class UserService {
 
     private final UserMapper userMapper;
 
-    @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(User user) {
         return userMapper.toUserInfoResponse(user);
     }


### PR DESCRIPTION
## 작업 내역
- 유저 정보(닉네임)을 조회하는 API 추가
- 특정 날짜의 감정 구슬을 조회하는 API 추가
- User를 영속상태로 만들기 위해 조회하는 공통 로직을 UserManager로 위임 

## 고민한 사항

## 리뷰 요청사항
- 간단한 API라 흐름이 적절한지 검토 부탁드려요~!
- 새로 만든 UserManager와 어디에서 쓰이는지 확인 부탁드려요~!