### PR TITLE
[T3-131] 엔드 포인트 수정 및 루틴 단건 조회 서비스 로직 수정

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/EmotionMarbleController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/EmotionMarbleController.java
@@ -8,9 +8,9 @@ import bitnagil.bitnagil_backend.emotionMarble.service.EmotionMarbleService;
 import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.user.domain.User;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -38,11 +38,11 @@ public class EmotionMarbleController implements EmotionMarbleSpec {
     }
 
     // 당일의 유저가 선택한 감정 구슬 조회 API
-    @GetMapping("/me")
-    public CustomResponseDto<EmotionMarbleTypeResponse> getEmotionMarbleForHome(
+    @GetMapping("/{searchDate}")
+    public CustomResponseDto<EmotionMarbleTypeResponse> getEmotionMarbleBySearchDate(
         @CurrentUser User user,
-        @RequestParam @NotNull LocalDate searchDate) {
+        @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate searchDate) {
 
-        return CustomResponseDto.from(emotionMarbleService.getEmotionMarbleForHome(user, searchDate));
+        return CustomResponseDto.from(emotionMarbleService.getEmotionMarbleBySearchDate(user, searchDate));
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/spec/EmotionMarbleSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/spec/EmotionMarbleSpec.java
@@ -12,6 +12,7 @@ import bitnagil.bitnagil_backend.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 
@@ -19,6 +20,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = ApiTags.EMOTION_MARBLE)
@@ -34,9 +36,9 @@ public interface EmotionMarbleSpec {
 
     @Operation(summary = "검색 날짜 기준으로 대한 유저의 감정구슬 정보를 조회합니다.")
     @Parameters({
-        @Parameter(name = "searchDate", description = "감정 구슬 조회 날짜", required = true, example = "2025-07-01")
+        @Parameter(name = "searchDate", description = "감정 구슬 조회 날짜", required = true, example = "2025-07-01",
+            in = ParameterIn.PATH)
     })
-    CustomResponseDto<EmotionMarbleTypeResponse> getEmotionMarbleForHome(
-        @CurrentUser User user,
-        @RequestParam @NotNull LocalDate searchDate);
+    CustomResponseDto<EmotionMarbleTypeResponse> getEmotionMarbleBySearchDate(
+        User user, @PathVariable LocalDate searchDate);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/service/EmotionMarbleService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/service/EmotionMarbleService.java
@@ -71,7 +71,7 @@ public class EmotionMarbleService {
     }
 
     @Transactional(readOnly = true)
-    public EmotionMarbleTypeResponse getEmotionMarbleForHome(User user, LocalDate searchDate) {
+    public EmotionMarbleTypeResponse getEmotionMarbleBySearchDate(User user, LocalDate searchDate) {
         EmotionMarble emotionMarble = emotionMarbleRepository.findByUserIdAndDateIs(
             user.getUserPk().getId(), searchDate);
 

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -192,6 +192,7 @@ public class RoutineService {
         return queryRoutines(user, startDate, endDate);
     }
 
+    // TODO: 추후에 어떤 루틴인지 식별이 필요할 때 RoutineType 추가 요망
     // routineId에 대한 단일 루틴 조회하는 메서드입니다.
     @Transactional(readOnly = true)
     public RoutineSearchResultDto getRoutine(User user, UUID routineId) {
@@ -199,7 +200,9 @@ public class RoutineService {
 
         Routine routine = routineValidator.validateRoutineOwnership(routineId, user, now);
 
-        List<SubRoutine> subRoutines = subRoutineRepository.findByRoutineId(routine.getRoutinePk().getId());
+        List<SubRoutine> subRoutines = subRoutineRepository
+            .findByRoutineIdAndDeletedAtIsNullAndHistoryStartDateTimeBeforeAndHistoryEndDateTimeGreaterThanEqual(
+                routineId, now, now);
 
         // 서브 루틴 목록 Dto로 변환
         List<SubRoutineSearchResultDto> subRoutineSearchResultDtos =

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserController.java
@@ -19,7 +19,7 @@ public class UserController implements UserSpec {
 
     private final UserService userService;
 
-    @GetMapping("/nickname")
+    @GetMapping("/infos")
     public CustomResponseDto<UserInfoResponse> getUserInfo(@CurrentUser User user) {
         UserInfoResponse userInfoResponse = userService.getUserInfo(user);
 


### PR DESCRIPTION
## 작업 내역
- 유저 닉네임 조회 엔드포인트 명확하게 수정
- 감정 구슬 조회 엔트포인트 명확하게 수정
- 루틴 단건 조회 서비스 로직에서 서브 루틴 조회 쿼리메서드 변경 (활성상태인 서브루틴을 가져오도록 변경)

## 고민한 사항

## 리뷰 요청사항