### PR TITLE
[T3-143] 선택한 요일(당일) 삭제 시 변경된 루틴에 대한 분기처리

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/changedRoutine/domain/ChangedRoutine.java
+++ b/src/main/java/bitnagil/bitnagil_backend/changedRoutine/domain/ChangedRoutine.java
@@ -74,4 +74,8 @@ public class ChangedRoutine extends BaseTimeEntity {
         this.routineId = routineId;
     }
 
+    public void updateChangedDivCode(ChangedDivCode changedDivCode) {
+        this.changedDivCode = changedDivCode;
+    }
+
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routine/request/DeleteRoutineByDayRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/request/DeleteRoutineByDayRequest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -23,6 +24,12 @@ public class DeleteRoutineByDayRequest {
             required = true)
     @NotNull
     private UUID routineId;
+
+    @Schema(description = "루틴에 대한 타입 값입니다.",
+            example = "CHANGED_ROUTINE",
+            required = true)
+    @NotNull
+    private RoutineType routineType;
 
     @Schema(description = "세부루틴 완료 여부 정보를 담은 리스트입니다.",
             example = "["

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -163,22 +163,32 @@ public class RoutineService {
     public void deleteRoutineByDay(User user, DeleteRoutineByDayRequest request) {
         LocalDateTime now = LocalDateTime.now();
 
-        Routine routine = routineValidator.validateRoutineOwnership(request.getRoutineId(), user, now);
+        if (request.getRoutineType() == RoutineType.ROUTINE) {
+            Routine routine = routineValidator.validateRoutine(user, request.getRoutineId(), request.getHistorySeq());
 
-        ChangedRoutine changedRoutineForDelete = routineFactory.createChangedRoutineForDelete(request, routine, now);
-        changedRoutineRepository.save(changedRoutineForDelete);
+            // 변경 루틴으로 전환
+            ChangedRoutine changedRoutineForDelete = routineFactory.createChangedRoutineForDelete(request, routine, now);
+            changedRoutineRepository.save(changedRoutineForDelete);
+
+            List<SubRoutine> subRoutines = subRoutineRepository.findByRoutineId(routine.getRoutinePk().getId());
+
+            // 변경 서브루틴으로 전환
+            for (SubRoutine subRoutine : subRoutines) {
+                ChangedSubRoutine changedSubRoutineForDelete =
+                    routineFactory.createChangedSubRoutineForDelete(subRoutine, now, changedRoutineForDelete);
+                changedSubRoutineRepository.save(changedSubRoutineForDelete);
+            }
+        }
+        else if (request.getRoutineType() == RoutineType.CHANGED_ROUTINE) {
+            ChangedRoutine changedRoutine = routineValidator.validateChangedRoutine(user, request.getRoutineId(),
+                request.getHistorySeq());
+
+            // 기존 변경 루틴의 결정 코드를 "오늘만 루틴 삭제"로 변경
+            changedRoutine.updateChangedDivCode(ChangedDivCode.TODAY_DELETE);
+        }
 
         // routineCompletionId에 해당하는 완료 여부 데이터 삭제
         deleteRoutineCompletionIfRoutineIdMatches(request.getRoutineCompletionId(), request.getRoutineId());
-
-        // 변경 서브루틴으로 전환
-        List<SubRoutine> subRoutines = subRoutineRepository.findByRoutineId(routine.getRoutinePk().getId());
-
-        for (SubRoutine subRoutine : subRoutines) {
-            ChangedSubRoutine changedSubRoutineForDelete =
-                routineFactory.createChangedSubRoutineForDelete(subRoutine, now, changedRoutineForDelete);
-            changedSubRoutineRepository.save(changedSubRoutineForDelete);
-        }
 
         // routineCompletionId에 해당하는 완료 여부 데이터 삭제
         for (SubRoutineInfoForDelete info : request.getSubRoutineInfosForDelete()) {

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineValidator.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineValidator.java
@@ -15,9 +15,9 @@ import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
 import bitnagil.bitnagil_backend.routine.domain.Routine;
 import bitnagil.bitnagil_backend.routine.domain.SubRoutine;
-import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 import bitnagil.bitnagil_backend.routine.repository.RoutineRepository;
 import bitnagil.bitnagil_backend.routine.repository.SubRoutineRepository;
+import bitnagil.bitnagil_backend.routine.request.DeleteRoutineByDayRequest;
 import bitnagil.bitnagil_backend.routine.request.RoutineCompletionInfo;
 import bitnagil.bitnagil_backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -38,16 +38,16 @@ public class RoutineValidator {
     public void validateRoutineOwnership(User user, RoutineCompletionInfo info) {
         switch (info.getRoutineType()) {
             case ROUTINE:
-                validateRoutine(user, info);
+                validateRoutine(user, info.getRoutineId(), info.getHistorySeq());
                 break;
             case SUB_ROUTINE:
-                validateSubRoutine(user, info);
+                validateSubRoutine(user, info.getRoutineId(), info.getHistorySeq());
                 break;
             case CHANGED_ROUTINE:
-                validateChangedRoutine(user, info);
+                validateChangedRoutine(user, info.getRoutineId(), info.getHistorySeq());
                 break;
             case CHANGED_SUB_ROUTINE:
-                validateChangedSubRoutine(user, info);
+                validateChangedSubRoutine(user, info.getRoutineId(), info.getHistorySeq());
                 break;
         }
     }
@@ -67,19 +67,21 @@ public class RoutineValidator {
         return routine;
     }
 
-    private void validateRoutine(User user, RoutineCompletionInfo info) {
+    public Routine validateRoutine(User user, UUID routineId, Long historySeq) {
         Routine routine = routineRepository
-            .findByRoutinePk(new HistoryPk(info.getRoutineId(), info.getHistorySeq()))
+            .findByRoutinePk(new HistoryPk(routineId, historySeq))
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE));
 
         if (!user.getUserPk().getId().equals(routine.getUserId())) {
             throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
         }
+
+        return routine;
     }
 
-    private void validateSubRoutine(User user, RoutineCompletionInfo info) {
+    private void validateSubRoutine(User user, UUID routineId, Long historySeq) {
         SubRoutine subRoutine = subRoutineRepository
-            .findBySubRoutinePk(new HistoryPk(info.getRoutineId(), info.getHistorySeq()))
+            .findBySubRoutinePk(new HistoryPk(routineId, historySeq))
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SUB_ROUTINE));
 
         // 추후 성능 이슈가 발생할 수 있는 부분
@@ -90,19 +92,21 @@ public class RoutineValidator {
         }
     }
 
-    private void validateChangedRoutine(User user, RoutineCompletionInfo info) {
+    public ChangedRoutine validateChangedRoutine(User user, UUID routineId, Long historySeq) {
         ChangedRoutine changedRoutine = changedRoutineRepository
-            .findByChangedRoutinePk(new HistoryPk(info.getRoutineId(), info.getHistorySeq()))
+            .findByChangedRoutinePk(new HistoryPk(routineId, historySeq))
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHANGED_ROUTINE));
 
         if (!user.getUserPk().getId().equals(changedRoutine.getUserId())) {
             throw new CustomException(ErrorCode.CHANGED_ROUTINE_USER_NOT_MATCHED);
         }
+
+        return changedRoutine;
     }
 
-    private void validateChangedSubRoutine(User user, RoutineCompletionInfo info) {
+    private void validateChangedSubRoutine(User user, UUID routineId, Long historySeq) {
         ChangedSubRoutine changedSubRoutine = changedSubRoutineRepository
-            .findByChangedSubRoutinePk(new HistoryPk(info.getRoutineId(), info.getHistorySeq()))
+            .findByChangedSubRoutinePk(new HistoryPk(routineId, historySeq))
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHANGED_SUB_ROUTINE));
 
         List<ChangedRoutine> changedRoutines = changedRoutineRepository.findByChangedRoutinePk_Id(


### PR DESCRIPTION
## 작업 내역
- 기존에는 선택한 요일(당일)만 삭제 시 루틴만 처리가 되고 있었습니다. 온보딩에서 등록된 루틴은 변경된 루틴으로 포함되기 때문에 이에 따라 변경된 루틴도 '선택한 요일(당일)만 삭제' API에서 처리가 되도록 수정하였습니다.

## 고민한 사항

## 리뷰 요청사항