### PR TITLE
[T3-150] 루틴 정보 등록 및 루틴 시작, 종료일자 기반의 루틴 생성

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/global/swagger/ApiTags.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/swagger/ApiTags.java
@@ -8,7 +8,7 @@ public class ApiTags {
     public static final String USER_AUTH = "유저 인증 API";
     public static final String HEALTH_CHECK = "헬스체크 API";
     public static final String ROUTINE = "루틴 API";
-    public static final String ROUTINEV2 = "[V2] 루틴 API";
+    public static final String ROUTINEV2 = "[v2] 루틴 API";
     public static final String ONBOARDING = "온보딩 API";
     public static final String EMOTION_MARBLE = "감정구슬 API";
     public static final String RECOMMENDED_ROUTINE = "추천 루틴 API";

--- a/src/main/java/bitnagil/bitnagil_backend/global/swagger/ApiTags.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/swagger/ApiTags.java
@@ -8,6 +8,7 @@ public class ApiTags {
     public static final String USER_AUTH = "유저 인증 API";
     public static final String HEALTH_CHECK = "헬스체크 API";
     public static final String ROUTINE = "루틴 API";
+    public static final String ROUTINEV2 = "[V2] 루틴 API";
     public static final String ONBOARDING = "온보딩 API";
     public static final String EMOTION_MARBLE = "감정구슬 API";
     public static final String RECOMMENDED_ROUTINE = "추천 루틴 API";

--- a/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
@@ -21,10 +21,10 @@ import bitnagil.bitnagil_backend.recommendedRoutine.repository.RecommendedSubRou
 import bitnagil.bitnagil_backend.recommendedRoutine.service.RecommendedRoutineManager;
 import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
 import bitnagil.bitnagil_backend.routineInfoV2.repository.RoutineInfoV2Repository;
-import bitnagil.bitnagil_backend.routineInfoV2.service.RoutineInfoFactoryV2;
+import bitnagil.bitnagil_backend.routineInfoV2.service.RoutineInfoV2Factory;
 import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
 import bitnagil.bitnagil_backend.routineV2.repository.RoutineV2Repository;
-import bitnagil.bitnagil_backend.routineV2.service.RoutineFactoryV2;
+import bitnagil.bitnagil_backend.routineV2.service.RoutineV2Factory;
 import bitnagil.bitnagil_backend.user.domain.User;
 import bitnagil.bitnagil_backend.user.service.UserManager;
 import lombok.RequiredArgsConstructor;
@@ -57,8 +57,8 @@ public class OnboardingService {
     private final RoutineInfoV2Repository routineInfoV2Repository;
     private final RoutineV2Repository routineV2Repository;
 
-    private final RoutineFactoryV2 routineFactoryV2;
-    private final RoutineInfoFactoryV2 routineInfoFactory;
+    private final RoutineV2Factory routineV2Factory;
+    private final RoutineInfoV2Factory routineInfoV2Factory;
 
 
     /**
@@ -108,7 +108,7 @@ public class OnboardingService {
                     .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECOMMENDED_ROUTINE));
 
             // 온보딩으로 등록한 루틴은 루틴 시작, 종료일자가 당일로 설정된다.
-            RoutineInfoV2 routineInfo = routineInfoFactory.createNewRoutineInfo(
+            RoutineInfoV2 routineInfo = routineInfoV2Factory.createNewRoutineInfo(
                     recommendedRoutine.getRecommendedRoutineName(),
                     List.of(), // 온보딩은 반복일자를 설정하지 않는다.
                     recommendedRoutine.getExecutionTime(),
@@ -128,18 +128,14 @@ public class OnboardingService {
                     .map(RecommendedSubRoutine::getSubRoutineName)
                     .toList();
 
-            // 서브 루틴 완료 여부 리스트 생성
-            List<Boolean> subRoutineCompleteYn = recommendedSubRoutines.stream()
-                    .map(completeYn -> false)
-                    .toList();
-
             // 루틴 정보에 해당하는 루틴을 생성한다.
-            RoutineV2 routine = routineFactoryV2.createNewRoutine(
+            RoutineV2 routine = routineV2Factory.createNewRoutine(
                     today,
                     false,
                     subRoutineNames,
-                    subRoutineCompleteYn,
-                    routineInfo);
+                    routineInfo,
+                    subRoutineNames.size()); // 서브 루틴 이름의 개수만큼 완료 여부를 생성
+
             routineV2Repository.save(routine);
         }
     }

--- a/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
@@ -128,12 +128,18 @@ public class OnboardingService {
                     .map(RecommendedSubRoutine::getSubRoutineName)
                     .toList();
 
+            // 서브 루틴 완료 여부 리스트 생성
+            List<Boolean> subRoutineCompleteYn = recommendedSubRoutines.stream()
+                .map(completeYn -> false)
+                .toList();
+
             // 루틴 정보에 해당하는 루틴을 생성한다.
             RoutineV2 routine = routineV2Factory.createNewRoutine(
                     today,
                     false,
                     subRoutineNames,
-                    routineInfo); // 서브 루틴 이름의 개수만큼 완료 여부를 생성
+                    subRoutineCompleteYn,
+                    routineInfo);
 
             routineV2Repository.save(routine);
         }

--- a/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
@@ -133,8 +133,7 @@ public class OnboardingService {
                     today,
                     false,
                     subRoutineNames,
-                    routineInfo,
-                    subRoutineNames.size()); // 서브 루틴 이름의 개수만큼 완료 여부를 생성
+                    routineInfo); // 서브 루틴 이름의 개수만큼 완료 여부를 생성
 
             routineV2Repository.save(routine);
         }

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+import bitnagil.bitnagil_backend.global.entity.BaseTimeEntity;
 import bitnagil.bitnagil_backend.global.utils.DayOfWeekConverter;
 import bitnagil.bitnagil_backend.user.domain.User;
 import jakarta.persistence.Convert;
@@ -31,7 +32,7 @@ import org.hibernate.annotations.Where;
 @Entity
 @SQLDelete(sql = "UPDATE routine_info_v2 SET deleted_at = NOW() WHERE routine_info_id = ?")
 @Where(clause = "deleted_at IS NULL")
-public class RoutineInfoV2 {
+public class RoutineInfoV2 extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long routineInfoId; // 루틴 정보 ID

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/service/RoutineInfoV2Factory.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/service/RoutineInfoV2Factory.java
@@ -13,7 +13,7 @@ import java.util.List;
  * 루틴 관련 엔티티 생성, 초기화 책임을 담당하는 클래스입니다.
  */
 @Component
-public class RoutineInfoFactoryV2 {
+public class RoutineInfoV2Factory {
 
     // 신규 RoutineInfo 엔티티 생성 및 초기화
     public RoutineInfoV2 createNewRoutineInfo(String routineName, List<DayOfWeek> routineRepeatDay,

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/RoutineV2Controller.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/RoutineV2Controller.java
@@ -1,0 +1,29 @@
+package bitnagil.bitnagil_backend.routineV2.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
+import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
+import bitnagil.bitnagil_backend.routineV2.controller.spec.RoutineV2Spec;
+import bitnagil.bitnagil_backend.routineV2.request.RegisterRoutineV2Request;
+import bitnagil.bitnagil_backend.routineV2.service.RoutineV2Service;
+import bitnagil.bitnagil_backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/v2/routines")
+public class RoutineV2Controller implements RoutineV2Spec {
+
+    private final RoutineV2Service routineV2Service;
+
+    @PostMapping("")
+    public CustomResponseDto<Object> registerRoutine(@CurrentUser User user, @RequestBody RegisterRoutineV2Request request) {
+        routineV2Service.registerRoutineV2(user, request);
+
+        return CustomResponseDto.from(null);
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
@@ -1,0 +1,15 @@
+package bitnagil.bitnagil_backend.routineV2.controller.spec;
+
+import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
+import bitnagil.bitnagil_backend.global.swagger.ApiTags;
+import bitnagil.bitnagil_backend.routineV2.request.RegisterRoutineV2Request;
+import bitnagil.bitnagil_backend.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = ApiTags.ROUTINEV2)
+public interface RoutineV2Spec {
+
+    @Operation(summary = "루틴 정보 등록 및 루틴 시작, 종료일자 사이에서 반복요일에 해당하는 날짜로 루틴 데이터를 생성합니다.")
+    CustomResponseDto<Object> registerRoutine(User user, RegisterRoutineV2Request request);
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
@@ -3,6 +3,7 @@ package bitnagil.bitnagil_backend.routineV2.domain;
 import java.time.LocalDate;
 import java.util.List;
 
+import bitnagil.bitnagil_backend.global.entity.BaseTimeEntity;
 import bitnagil.bitnagil_backend.global.utils.BooleanListConverter;
 import bitnagil.bitnagil_backend.global.utils.StringListConverter;
 import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
@@ -30,7 +31,7 @@ import org.hibernate.annotations.Where;
 @Entity
 @SQLDelete(sql = "UPDATE routine_v2 SET deleted_at = NOW() WHERE routine_id = ?")
 @Where(clause = "deleted_at IS NULL")
-public class RoutineV2 {
+public class RoutineV2 extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long routineId; // 일일 루틴 ID

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/request/RegisterRoutineV2Request.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/request/RegisterRoutineV2Request.java
@@ -1,6 +1,7 @@
-package bitnagil.bitnagil_backend.routine.request;
+package bitnagil.bitnagil_backend.routineV2.request;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Schema(description = "루틴 등록 요청 DTO")
-public class RegisterRoutineRequest {
+public class RegisterRoutineV2Request {
 
     @Schema(description = "루틴 이름입니다.",
             example = "아침 준비",
@@ -20,19 +21,31 @@ public class RegisterRoutineRequest {
     @NotNull
     private String routineName;
 
-    @Schema(description = "반복 요일에 대한 리스트입니다.",
+    @Schema(description = "반복 요일에 대한 리스트입니다. (반복요일이 없으면 당일 루틴입니다.)",
             example = "[\"MONDAY\", \"FRIDAY\"]",
             required = true)
     @NotNull
     private List<DayOfWeek> repeatDay;
 
-    @Schema(description = "루틴 시작 시간입니다.",
-            example = "08:15:00",
+    @Schema(description = "루틴 시작 일자입니다.",
+            example = "2025-08-01",
             required = true)
+    @NotNull
+    private LocalDate routineStartDate;
+
+    @Schema(description = "루틴 시작 일자입니다.",
+            example = "2025-08-31",
+            required = true)
+    @NotNull
+    private LocalDate routineEndDate;
+
+    @Schema(description = "루틴 시작 시간입니다.",
+        example = "08:15:00",
+        required = true)
     @NotNull
     private LocalTime executionTime;
 
     @Schema(description = "세부 루틴 이름에 대한 리스트입니다.",
-            example = "[\"손 씻기\", \"세수 하기\", \"양치 하기\"]")
+        example = "[\"손 씻기\", \"세수 하기\", \"양치 하기\"]")
     private List<String> subRoutineName;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Factory.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Factory.java
@@ -2,26 +2,35 @@ package bitnagil.bitnagil_backend.routineV2.service;
 
 import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
 import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
+
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * 루틴 관련 엔티티 생성, 초기화 책임을 담당하는 클래스입니다.
  */
 @Component
-public class RoutineFactoryV2 {
+public class RoutineV2Factory {
 
     // 신규 Routine 엔티티 생성 및 초기화
     public RoutineV2 createNewRoutine(LocalDate routineDate, Boolean routineCompleteYn, List<String> subRoutineNames,
-                                      List<Boolean> subRoutineCompleteYn, RoutineInfoV2 routineInfo) {
+                                      RoutineInfoV2 routineInfo, Integer subRoutineCnt) {
         return RoutineV2.builder()
                 .routineDate(routineDate)
                 .routineCompleteYn(routineCompleteYn)
                 .subRoutineNames(subRoutineNames)
-                .subRoutineCompleteYn(subRoutineCompleteYn)
+                .subRoutineCompleteYn(initSubRoutineCompleteYn(subRoutineCnt))
                 .routineInfo(routineInfo)
                 .build();
+    }
+
+    private  List<Boolean> initSubRoutineCompleteYn(Integer subRoutineCnt) {
+        return IntStream.range(0, subRoutineCnt)
+            .mapToObj(i -> false)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Factory.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Factory.java
@@ -28,6 +28,7 @@ public class RoutineV2Factory {
                 .build();
     }
 
+    // 서브루틴 완료 여부 리스트를 초기화 및 생성
     private  List<Boolean> initSubRoutineCompleteYn(Integer subRoutineCnt) {
         return IntStream.range(0, subRoutineCnt)
             .mapToObj(i -> false)

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Factory.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Factory.java
@@ -18,12 +18,12 @@ public class RoutineV2Factory {
 
     // 신규 Routine 엔티티 생성 및 초기화
     public RoutineV2 createNewRoutine(LocalDate routineDate, Boolean routineCompleteYn, List<String> subRoutineNames,
-                                      RoutineInfoV2 routineInfo, Integer subRoutineCnt) {
+                                      RoutineInfoV2 routineInfo) {
         return RoutineV2.builder()
                 .routineDate(routineDate)
                 .routineCompleteYn(routineCompleteYn)
                 .subRoutineNames(subRoutineNames)
-                .subRoutineCompleteYn(initSubRoutineCompleteYn(subRoutineCnt))
+                .subRoutineCompleteYn(initSubRoutineCompleteYn(subRoutineNames.size()))
                 .routineInfo(routineInfo)
                 .build();
     }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Factory.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Factory.java
@@ -7,8 +7,6 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * 루틴 관련 엔티티 생성, 초기화 책임을 담당하는 클래스입니다.
@@ -18,20 +16,13 @@ public class RoutineV2Factory {
 
     // 신규 Routine 엔티티 생성 및 초기화
     public RoutineV2 createNewRoutine(LocalDate routineDate, Boolean routineCompleteYn, List<String> subRoutineNames,
-                                      RoutineInfoV2 routineInfo) {
+                                      List<Boolean> subRoutineCompleteYn, RoutineInfoV2 routineInfo) {
         return RoutineV2.builder()
                 .routineDate(routineDate)
                 .routineCompleteYn(routineCompleteYn)
                 .subRoutineNames(subRoutineNames)
-                .subRoutineCompleteYn(initSubRoutineCompleteYn(subRoutineNames.size()))
+                .subRoutineCompleteYn(subRoutineCompleteYn)
                 .routineInfo(routineInfo)
                 .build();
-    }
-
-    // 서브루틴 완료 여부 리스트를 초기화 및 생성
-    private  List<Boolean> initSubRoutineCompleteYn(Integer subRoutineCnt) {
-        return IntStream.range(0, subRoutineCnt)
-            .mapToObj(i -> false)
-            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -53,8 +53,7 @@ public class RoutineV2Service {
                 today,
                 false,
                 request.getSubRoutineName(),
-                routineInfo,
-                subRoutineCnt);
+                routineInfo);
 
             routineV2Repository.save(routine);
         }
@@ -83,8 +82,7 @@ public class RoutineV2Service {
                     routineDate,
                     false,
                     request.getSubRoutineName(),
-                    routineInfo,
-                    subRoutineCnt
+                    routineInfo
                 ))
                 .toList();
 

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -1,0 +1,110 @@
+package bitnagil.bitnagil_backend.routineV2.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
+import bitnagil.bitnagil_backend.routineInfoV2.repository.RoutineInfoV2Repository;
+import bitnagil.bitnagil_backend.routineInfoV2.service.RoutineInfoV2Factory;
+import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
+import bitnagil.bitnagil_backend.routineV2.repository.RoutineV2Repository;
+import bitnagil.bitnagil_backend.routineV2.request.RegisterRoutineV2Request;
+import bitnagil.bitnagil_backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineV2Service {
+
+    private final RoutineInfoV2Repository routineInfoV2Repository;
+    private final RoutineInfoV2Factory routineInfoV2Factory;
+    private final RoutineV2Factory routineV2Factory;
+    private final RoutineV2Repository routineV2Repository;
+
+    /**
+     * 루틴 정보를 등록하면서 루틴 시작, 종료일자를 기반으로 루틴 내역을 생성
+     */
+    @Transactional
+    public void registerRoutineV2(User user, RegisterRoutineV2Request request) {
+
+        LocalDate today = LocalDate.now();
+        int subRoutineCnt = request.getSubRoutineName().size();
+
+        // 당일 루틴 등록 시
+        if (request.getRepeatDay().isEmpty()) {
+            //루틴 정보 등록
+            RoutineInfoV2 routineInfo = routineInfoV2Factory.createNewRoutineInfo(
+                request.getRoutineName(),
+                List.of(), // 당일 루틴이기 때문에 반복 요일은 빈 리스트
+                request.getExecutionTime(),
+                request.getRoutineStartDate(),
+                request.getRoutineEndDate(),
+                user);
+
+            routineInfoV2Repository.save(routineInfo);
+
+            // 루틴 정보에 해당하는 루틴을 생성한다.
+            RoutineV2 routine = routineV2Factory.createNewRoutine(
+                today,
+                false,
+                request.getSubRoutineName(),
+                routineInfo,
+                subRoutineCnt);
+
+            routineV2Repository.save(routine);
+        }
+        else { // 반복 요일이 있는 루틴의 경우
+            //루틴 정보 등록
+            RoutineInfoV2 routineInfo = routineInfoV2Factory.createNewRoutineInfo(
+                request.getRoutineName(),
+                request.getRepeatDay(),
+                request.getExecutionTime(),
+                request.getRoutineStartDate(),
+                request.getRoutineEndDate(),
+                user);
+
+            routineInfoV2Repository.save(routineInfo);
+
+            // 날짜 범위 내 지정된 요일에 해당하는 날짜 목록 생성
+            List<LocalDate> targetDates = generateRoutineDatesWithinPeriod(
+                request.getRoutineStartDate(),
+                request.getRoutineEndDate(),
+                request.getRepeatDay()
+            );
+
+            // 위 날짜 목록을 순회하며 RoutineV2 생성
+            List<RoutineV2> routinesToRegister = targetDates.stream()
+                .map(routineDate -> routineV2Factory.createNewRoutine(
+                    routineDate,
+                    false,
+                    request.getSubRoutineName(),
+                    routineInfo,
+                    subRoutineCnt
+                ))
+                .toList();
+
+            routineV2Repository.saveAll(routinesToRegister);
+        }
+    }
+
+    /**
+     * 날짜 범위에서 주어진 요일(repeatDays)에 해당하는 날짜만 반환
+     */
+    private List<LocalDate> generateRoutineDatesWithinPeriod(
+        LocalDate startDate, LocalDate endDate, List<DayOfWeek> repeatDays) {
+
+        List<LocalDate> routineDatesToRegister = new ArrayList<>();
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            if (repeatDays.contains(date.getDayOfWeek())) {
+                routineDatesToRegister.add(date);
+            }
+        }
+        return routineDatesToRegister;
+    }
+
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -36,61 +36,40 @@ public class RoutineV2Service {
     public void registerRoutineV2(User user, RegisterRoutineV2Request request) {
 
         LocalDate today = LocalDate.now();
-        int subRoutineCnt = request.getSubRoutineName().size();
 
-        // 당일 루틴 등록 시
-        if (request.getRepeatDay().isEmpty()) {
-            //루틴 정보 등록
-            RoutineInfoV2 routineInfo = routineInfoV2Factory.createNewRoutineInfo(
-                request.getRoutineName(),
-                List.of(), // 당일 루틴이기 때문에 반복 요일은 빈 리스트
-                request.getExecutionTime(),
+        // repeatDay가 비어 있으면 빈 리스트, 아니면 요청값 사용
+        List<DayOfWeek> repeatDays = request.getRepeatDay().isEmpty() ? List.of() : request.getRepeatDay();
+
+        // 루틴 정보 등록
+        RoutineInfoV2 routineInfo = routineInfoV2Factory.createNewRoutineInfo(
+            request.getRoutineName(),
+            repeatDays,
+            request.getExecutionTime(),
+            request.getRoutineStartDate(),
+            request.getRoutineEndDate(),
+            user);
+
+        routineInfoV2Repository.save(routineInfo);
+
+        // 루틴을 생성할 날짜 목록 생성
+        List<LocalDate> targetDates = request.getRepeatDay().isEmpty()
+            ? List.of(today) // 당일 루틴
+            : generateRoutineDatesWithinPeriod(
                 request.getRoutineStartDate(),
                 request.getRoutineEndDate(),
-                user);
+                request.getRepeatDay());
 
-            routineInfoV2Repository.save(routineInfo);
-
-            // 루틴 정보에 해당하는 루틴을 생성한다.
-            RoutineV2 routine = routineV2Factory.createNewRoutine(
-                today,
+        // 위 날짜 목록을 바탕으로 루틴 생성
+        List<RoutineV2> routinesToRegister = targetDates.stream()
+            .map(routineDate -> routineV2Factory.createNewRoutine(
+                routineDate,
                 false,
                 request.getSubRoutineName(),
-                routineInfo);
+                routineInfo
+            ))
+            .toList();
 
-            routineV2Repository.save(routine);
-        }
-        else { // 반복 요일이 있는 루틴의 경우
-            //루틴 정보 등록
-            RoutineInfoV2 routineInfo = routineInfoV2Factory.createNewRoutineInfo(
-                request.getRoutineName(),
-                request.getRepeatDay(),
-                request.getExecutionTime(),
-                request.getRoutineStartDate(),
-                request.getRoutineEndDate(),
-                user);
-
-            routineInfoV2Repository.save(routineInfo);
-
-            // 날짜 범위 내 지정된 요일에 해당하는 날짜 목록 생성
-            List<LocalDate> targetDates = generateRoutineDatesWithinPeriod(
-                request.getRoutineStartDate(),
-                request.getRoutineEndDate(),
-                request.getRepeatDay()
-            );
-
-            // 위 날짜 목록을 순회하며 RoutineV2 생성
-            List<RoutineV2> routinesToRegister = targetDates.stream()
-                .map(routineDate -> routineV2Factory.createNewRoutine(
-                    routineDate,
-                    false,
-                    request.getSubRoutineName(),
-                    routineInfo
-                ))
-                .toList();
-
-            routineV2Repository.saveAll(routinesToRegister);
-        }
+        routineV2Repository.saveAll(routinesToRegister);
     }
 
     /**

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -59,12 +59,18 @@ public class RoutineV2Service {
                 request.getRoutineEndDate(),
                 request.getRepeatDay());
 
+        // 서브 루틴 완료 여부 리스트 생성
+        List<Boolean> subRoutineCompleteYn = request.getSubRoutineName().stream()
+            .map(completeYn -> false)
+            .toList();
+
         // 위 날짜 목록을 바탕으로 루틴 생성
         List<RoutineV2> routinesToRegister = targetDates.stream()
             .map(routineDate -> routineV2Factory.createNewRoutine(
                 routineDate,
                 false,
                 request.getSubRoutineName(),
+                subRoutineCompleteYn,
                 routineInfo
             ))
             .toList();

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -17,6 +17,9 @@ import bitnagil.bitnagil_backend.routineV2.request.RegisterRoutineV2Request;
 import bitnagil.bitnagil_backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * [v2] 루틴 관련된 서비스 로직을 담은 클래스입니다.
+ */
 @Service
 @RequiredArgsConstructor
 public class RoutineV2Service {


### PR DESCRIPTION
## 작업 내역
- 기존 루틴 생성을 할 때 서비스 레이어에서 '서브 루틴 완료 여부 리스트 생성'을 RoutineV2Factory에게 위임하였습니다. 
   - 다른 곳에서도 공통적으로 사용되고, Factory의 역할에 가까운 로직이기에 위임을 하기로 하였습니다.
- 루틴 정보 등록 및 루틴 시작, 종료일자 기반의 루틴 생성 API 추가  
- API 테스트 완료

## 고민한 사항

## 리뷰 요청사항
- 작업 내역 기반의 전반적인 로직에 대해 리뷰 부탁드립니다~!