### PR TITLE
[T3-153] 루틴 단건, 다건 조회 API V2

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                 // GUEST 권한으로만 접근 가능한 경로
                 .requestMatchers("/api/v1/auth/agreements").hasRole("GUEST")
                 // ONBAORDING 권한으로만 접근 가능한 경로
-                .requestMatchers("/api/v1/onboardings", "/api/v2/onboardings", "/api/v1/users/infos").hasAnyRole("USER", "ONBOARDING")
+                .requestMatchers("/api/v1/onboardings", "/api/v1/onboardings/routines", "/api/v2/onboardings/routines", "/api/v1/users/infos").hasAnyRole("USER", "ONBOARDING")
                 // USER 권한으로만 접근 가능한 경로(전체)
                 .requestMatchers("/**").hasRole("USER")
                 .anyRequest().authenticated()

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/RoutineV2Controller.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/RoutineV2Controller.java
@@ -1,9 +1,8 @@
 package bitnagil.bitnagil_backend.routineV2.controller;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.bind.annotation.*;
 
 import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
@@ -13,12 +12,22 @@ import bitnagil.bitnagil_backend.routineV2.service.RoutineV2Service;
 import bitnagil.bitnagil_backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDate;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/api/v2/routines")
 public class RoutineV2Controller implements RoutineV2Spec {
 
     private final RoutineV2Service routineV2Service;
+
+    // 회원이 보유한 특정 기간(start_date, end_date)의 루틴을 조회하는 API입니다.
+    @GetMapping
+    public CustomResponseDto<RoutineV2SearchResponse> getRoutines(@CurrentUser User user,
+                                                                  @RequestParam @NotNull LocalDate startDate,
+                                                                  @RequestParam @NotNull LocalDate endDate) {
+        return CustomResponseDto.from(routineV2Service.getRoutines(user, startDate, endDate));
+    }
 
     @PostMapping("")
     public CustomResponseDto<Object> registerRoutine(@CurrentUser User user, @RequestBody RegisterRoutineV2Request request) {

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/RoutineV2Controller.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/RoutineV2Controller.java
@@ -1,6 +1,7 @@
 package bitnagil.bitnagil_backend.routineV2.controller;
 
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
+import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,6 +28,13 @@ public class RoutineV2Controller implements RoutineV2Spec {
                                                                   @RequestParam @NotNull LocalDate startDate,
                                                                   @RequestParam @NotNull LocalDate endDate) {
         return CustomResponseDto.from(routineV2Service.getRoutines(user, startDate, endDate));
+    }
+
+    // 루틴 단건 조회
+    @GetMapping("{routineId}")
+    public CustomResponseDto<RoutineV2SearchResultDto> getRoutine(@CurrentUser User user,
+                                                                  @PathVariable Long routineId) {
+        return CustomResponseDto.from(routineV2Service.getRoutine(user, routineId));
     }
 
     @PostMapping("")

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
@@ -1,11 +1,12 @@
 package bitnagil.bitnagil_backend.routineV2.controller.spec;
 
-import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
+import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
+import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExamples;
 import bitnagil.bitnagil_backend.global.swagger.ApiTags;
-import bitnagil.bitnagil_backend.routine.response.RoutineSearchResponse;
 import bitnagil.bitnagil_backend.routineV2.request.RegisterRoutineV2Request;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
+import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
 import bitnagil.bitnagil_backend.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Tag(name = ApiTags.ROUTINEV2)
 public interface RoutineV2Spec {
@@ -25,6 +27,11 @@ public interface RoutineV2Spec {
             @Parameter(name = "endDate", description = "조회 종료일", required = true, example = "2025-07-13")
     })
     CustomResponseDto<RoutineV2SearchResponse> getRoutines(User user, @NotNull LocalDate startDate, @NotNull LocalDate endDate);
+
+    @Operation(summary = "회원이 보유한 루틴을 단건 조회합니다.")
+    @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_ROUTINE})
+    CustomResponseDto<RoutineV2SearchResultDto> getRoutine(User user, Long routineId);
+
 
     @Operation(summary = "루틴 정보 등록 및 루틴 시작, 종료일자 사이에서 반복요일에 해당하는 날짜로 루틴 데이터를 생성합니다.")
     CustomResponseDto<Object> registerRoutine(User user, RegisterRoutineV2Request request);

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
@@ -1,14 +1,30 @@
 package bitnagil.bitnagil_backend.routineV2.controller.spec;
 
+import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.global.swagger.ApiTags;
+import bitnagil.bitnagil_backend.routine.response.RoutineSearchResponse;
 import bitnagil.bitnagil_backend.routineV2.request.RegisterRoutineV2Request;
+import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
 import bitnagil.bitnagil_backend.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
 
 @Tag(name = ApiTags.ROUTINEV2)
 public interface RoutineV2Spec {
+
+    @Operation(summary = "루틴 조회",
+            description = "회원이 특정 기간에 보유한 루틴에 대한 정보를 조회합니다.")
+    @Parameters({
+            @Parameter(name = "startDate", description = "조회 시작일", required = true, example = "2025-07-01"),
+            @Parameter(name = "endDate", description = "조회 종료일", required = true, example = "2025-07-13")
+    })
+    CustomResponseDto<RoutineV2SearchResponse> getRoutines(User user, @NotNull LocalDate startDate, @NotNull LocalDate endDate);
 
     @Operation(summary = "루틴 정보 등록 및 루틴 시작, 종료일자 사이에서 반복요일에 해당하는 날짜로 루틴 데이터를 생성합니다.")
     CustomResponseDto<Object> registerRoutine(User user, RegisterRoutineV2Request request);

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
@@ -44,11 +44,11 @@ public class RoutineV2 extends BaseTimeEntity {
 
     @NotNull
     @Convert(converter = StringListConverter.class)
-    List<String> subRoutineNames; // 서브 루틴 이름 리스트
+    private List<String> subRoutineNames; // 서브 루틴 이름 리스트
 
     @NotNull
     @Convert(converter = BooleanListConverter.class)
-    List<Boolean> subRoutineCompleteYn; // 서브 루틴 완료 여부 리스트
+    private List<Boolean> subRoutineCompleteYn; // 서브 루틴 완료 여부 리스트
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "routine_info_id")

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
@@ -28,4 +28,18 @@ public interface RoutineV2Repository extends JpaRepository<RoutineV2, Long> {
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
     );
+
+    /**
+     * 특정 사용자의 루틴을 ID로 조회하는 메서드입니다.
+     */
+    @Query("""
+        select r from RoutineV2 r
+        join fetch r.routineInfo ri
+        where ri.user = :user
+          and r.id = :routineId
+    """)
+    RoutineV2 findByUserAndRoutineId(
+            @Param("user") User user,
+            @Param("routineId") Long routineId
+    );
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoutineV2Repository extends JpaRepository<RoutineV2, Long> {
@@ -36,9 +37,9 @@ public interface RoutineV2Repository extends JpaRepository<RoutineV2, Long> {
         select r from RoutineV2 r
         join fetch r.routineInfo ri
         where ri.user = :user
-          and r.id = :routineId
+            and r.routineId = :routineId
     """)
-    RoutineV2 findByUserAndRoutineId(
+    Optional<RoutineV2> findByUserAndRoutineId(
             @Param("user") User user,
             @Param("routineId") Long routineId
     );

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
@@ -1,10 +1,31 @@
 package bitnagil.bitnagil_backend.routineV2.repository;
 
 import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
+import bitnagil.bitnagil_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface RoutineV2Repository extends JpaRepository<RoutineV2, Long> {
 
+    /**
+     * startDate와 endDate 사이에 있는 루틴을 조회하는 메서드입니다.
+     * fetch join을 사용하여 RoutineInfoV2와 함께 조회합니다.
+     */
+    @Query("""
+        select r from RoutineV2 r
+        join fetch r.routineInfo ri
+        where ri.user = :user
+          and r.routineDate between :startDate and :endDate
+    """)
+    List<RoutineV2> findByUserAndDateRange(
+            @Param("user") User user,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/response/RoutineV2SearchResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/response/RoutineV2SearchResponse.java
@@ -1,0 +1,18 @@
+package bitnagil.bitnagil_backend.routineV2.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RoutineV2SearchResponse {
+    @Schema(description = "날짜(LocalDate: 2025-08-01)와 같은 형태를 key로 가지는 루틴 목록 Map입니다. Swagger에서는 additionalProp1처럼 보일 수 있습니다.")
+    private Map<LocalDate, List<RoutineV2SearchResultDto>> routines; // 날짜별 루틴 목록
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/response/RoutineV2SearchResultDto.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/response/RoutineV2SearchResultDto.java
@@ -1,0 +1,34 @@
+package bitnagil.bitnagil_backend.routineV2.response;
+
+import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RoutineV2SearchResultDto {
+    @Schema(example = "1")
+    private String routineId; // RoutineV2의 ID(V2에서는 String으로 파싱해서 전달)
+    @Schema(example = "물마시기")
+    private String routineName; // 루틴 이름
+    @Schema(example = "[MONDAY, WEDNESDAY, FRIDAY]")
+    private List<DayOfWeek> repeatDay; // 반복 요일
+    @Schema(example = "08:30:00")
+    private LocalTime executionTime; // 루틴 실행 시간
+    @Schema(example = "2025-08-01")
+    private LocalDate routineDate; // 루틴 일자
+    @Schema(example = "true")
+    private Boolean routineCompleteYn;
+    @Schema(example = "[물 10초만에 마시기, 물 20초만에 마시기]")
+    private List<String> subRoutineNames;
+    @Schema(example = "[true, false]")
+    private List<Boolean> subRoutineCompleteYn;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Mapper.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Mapper.java
@@ -1,0 +1,37 @@
+package bitnagil.bitnagil_backend.routineV2.service;
+
+import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
+import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
+import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * 루틴 관련해서 DB에서 조회해오거나 가공된 데이터를 DTO로 변환하는 Mapper 클래스입니다.
+ */
+@Component
+public class RoutineV2Mapper {
+
+    public RoutineV2SearchResultDto toRoutineV2SearchResultDto(RoutineV2 routine){
+        return RoutineV2SearchResultDto.builder()
+                .routineId(String.valueOf(routine.getRoutineId()))
+                .routineName(routine.getRoutineInfo().getRoutineName())
+                .repeatDay(routine.getRoutineInfo().getRoutineRepeatDay())
+                .executionTime(routine.getRoutineInfo().getRoutineExecutionTime())
+                .routineDate(routine.getRoutineDate())
+                .routineCompleteYn(routine.getRoutineCompleteYn())
+                .subRoutineNames(routine.getSubRoutineNames())
+                .subRoutineCompleteYn(routine.getSubRoutineCompleteYn())
+                .build();
+    }
+
+    public RoutineV2SearchResponse toRoutineV2SearchResponse(Map<LocalDate, List<RoutineV2SearchResultDto>> response) {
+        return RoutineV2SearchResponse.builder()
+                .routines(response)
+                .build();
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -2,9 +2,10 @@ package bitnagil.bitnagil_backend.routineV2.service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
+import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
+import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,13 @@ public class RoutineV2Service {
     private final RoutineInfoV2Factory routineInfoV2Factory;
     private final RoutineV2Factory routineV2Factory;
     private final RoutineV2Repository routineV2Repository;
+    private final RoutineV2Mapper routineV2Mapper;
+
+    // 회원이 보유한 특정 기간(start_date, end_date)의 루틴을 조회하는 메서드입니다.
+    @Transactional(readOnly = true)
+    public RoutineV2SearchResponse getRoutines(User user, LocalDate startDate, LocalDate endDate) {
+        return queryRoutines(user, startDate, endDate);
+    }
 
     /**
      * 루틴 정보를 등록하면서 루틴 시작, 종료일자를 기반으로 루틴 내역을 생성
@@ -93,4 +101,24 @@ public class RoutineV2Service {
         return routineDatesToRegister;
     }
 
+    // 특정 기간 보유 루틴 조회
+    private RoutineV2SearchResponse queryRoutines(User user, LocalDate startDate, LocalDate endDate) {
+        Map<LocalDate, List<RoutineV2SearchResultDto>> response = new HashMap<>();
+
+        List<RoutineV2> routineList = routineV2Repository.findByUserAndDateRange(user, startDate, endDate);
+
+        for (RoutineV2 routineV2 : routineList) {
+            LocalDate date = routineV2.getRoutineDate();
+            RoutineV2SearchResultDto routineSearchResultDto = routineV2Mapper.toRoutineV2SearchResultDto(routineV2);
+
+            // 날짜별 리스트에 추가
+            response.computeIfAbsent(date, key -> new ArrayList<>()).add(routineSearchResultDto);
+        }
+
+        response.forEach((date, routineSearchResultDto) ->
+                routineSearchResultDto.sort(Comparator.comparing(RoutineV2SearchResultDto::getExecutionTime))
+        );
+
+        return routineV2Mapper.toRoutineV2SearchResponse(response);
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -4,6 +4,8 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.*;
 
+import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
+import bitnagil.bitnagil_backend.global.exception.CustomException;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
 import org.springframework.stereotype.Service;
@@ -31,10 +33,24 @@ public class RoutineV2Service {
     private final RoutineV2Repository routineV2Repository;
     private final RoutineV2Mapper routineV2Mapper;
 
-    // 회원이 보유한 특정 기간(start_date, end_date)의 루틴을 조회하는 메서드입니다.
+    /**
+     * 회원이 보유한 특정 기간(start_date, end_date)의 루틴을 조회하는 메서드입니다.
+     */
     @Transactional(readOnly = true)
     public RoutineV2SearchResponse getRoutines(User user, LocalDate startDate, LocalDate endDate) {
         return queryRoutines(user, startDate, endDate);
+    }
+
+    /**
+     * 회원이 보유한 루틴 단건 조회
+     */
+    @Transactional(readOnly = true)
+    public RoutineV2SearchResultDto getRoutine(User user, Long routineId) {
+        RoutineV2 routineV2 = routineV2Repository.findByUserAndRoutineId(user, routineId);
+        if(routineV2 == null) {
+            throw new CustomException(ErrorCode.NOT_FOUND_ROUTINE);
+        }
+        return routineV2Mapper.toRoutineV2SearchResultDto(routineV2);
     }
 
     /**

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -46,10 +46,9 @@ public class RoutineV2Service {
      */
     @Transactional(readOnly = true)
     public RoutineV2SearchResultDto getRoutine(User user, Long routineId) {
-        RoutineV2 routineV2 = routineV2Repository.findByUserAndRoutineId(user, routineId);
-        if(routineV2 == null) {
-            throw new CustomException(ErrorCode.NOT_FOUND_ROUTINE);
-        }
+        RoutineV2 routineV2 = routineV2Repository.findByUserAndRoutineId(user, routineId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE));
+
         return routineV2Mapper.toRoutineV2SearchResultDto(routineV2);
     }
 


### PR DESCRIPTION
## 작업 내역
- 루틴 단건 조회(routineId)
- 루틴 다건 조회(startDate, endDate)
- 엔티티 필드 접근제어자 누락 수정

## 고민한 사항

## 리뷰 요청사항
- routine과 routineInfo는 현재 조회시에 같이 조회가 되어야 하기 때문에 fetch join을 이용해서 한번에 조회해오고 있습니다.
- 혹시나 해당 부분에 추가 의견이 있다면 주세요