### PR TITLE
[T3-157] 루틴 삭제 서비스 로직에 v2가 호환되도록 수정

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/routine/controller/RoutineController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/controller/RoutineController.java
@@ -3,13 +3,11 @@ package bitnagil.bitnagil_backend.routine.controller;
 import java.time.LocalDate;
 import java.util.UUID;
 
-import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 import bitnagil.bitnagil_backend.routine.request.DeleteRoutineByDayRequest;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routine.response.RoutineSearchResultDto;
 import jakarta.validation.constraints.NotNull;
 
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,19 +15,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import bitnagil.bitnagil_backend.routine.request.RoutineSearchRequest;
 import bitnagil.bitnagil_backend.routine.response.RoutineSearchResponse;
 import org.springframework.web.bind.annotation.*;
 
 import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.routine.controller.spec.RoutineSpec;
-import bitnagil.bitnagil_backend.routine.domain.Routine;
 import bitnagil.bitnagil_backend.routine.request.RegisterRoutineRequest;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineRequest;
 import bitnagil.bitnagil_backend.routine.service.RoutineService;
 import bitnagil.bitnagil_backend.user.domain.User;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -56,7 +51,7 @@ public class RoutineController implements RoutineSpec {
     }
 
     @DeleteMapping("/{routineId}")
-    public CustomResponseDto<Object> deleteRoutine(@CurrentUser User user, @PathVariable UUID routineId) {
+    public CustomResponseDto<Object> deleteRoutine(@CurrentUser User user, @PathVariable String routineId) {
         routineService.deleteRoutine(user, routineId);
 
         return CustomResponseDto.from(null);

--- a/src/main/java/bitnagil/bitnagil_backend/routine/controller/spec/RoutineSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/controller/spec/RoutineSpec.java
@@ -3,10 +3,6 @@ package bitnagil.bitnagil_backend.routine.controller.spec;
 import java.time.LocalDate;
 import java.util.UUID;
 
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-
-import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExamples;
@@ -45,7 +41,7 @@ public interface RoutineSpec {
 
     @Operation(summary = "루틴 및 서브 루틴을 모두 삭제합니다.")
     @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_ROUTINE, ErrorCode.ROUTINE_USER_NOT_MATCHED})
-    CustomResponseDto<Object> deleteRoutine(User user, UUID routineId);
+    CustomResponseDto<Object> deleteRoutine(User user, String routineId);
 
     @Operation(summary = "여러 루틴의 완료 여부를 갱신합니다.")
     @ApiErrorCodeExamples({

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -286,13 +286,13 @@ public class RoutineService {
             throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
         }
 
-        routineInfoV2.updateRoutineEndDate(today); // 종료 일자를 삭제 당일로 변경
-        routineInfoV2Repository.delete(routineInfoV2); // 루틴 정보 삭제 (Sort Delete)
-
         // 오늘 이후 루틴 내역 모두 삭제 (Hard Delete)
         List<RoutineV2> routinesV2AfterToday = routineV2Repository
             .findByRoutineInfoAndRoutineDateAfter(routineInfoV2, today);
         routineV2Repository.deleteAll(routinesV2AfterToday);
+
+        routineInfoV2.updateRoutineEndDate(today); // 종료 일자를 삭제 당일로 변경
+        routineInfoV2Repository.delete(routineInfoV2); // 루틴 정보 삭제 (Sort Delete)
     }
 
     // 로그인한 유저가 등록한 루틴인지 검증하는 로직

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -175,7 +175,7 @@ public class RoutineService {
         }
         else { // (v2) routineId의 타입이 Long인 경우
             Long v2RoutineId = Long.valueOf(routineId);
-            deleteV2Routine(user, v2RoutineId, now, today);
+            deleteV2Routine(user, v2RoutineId, today);
         }
     }
 
@@ -276,7 +276,7 @@ public class RoutineService {
     }
 
     // v2에서 사용하는 루틴 삭제 메서드
-    private void deleteV2Routine(User user, Long v2RoutineId, LocalDateTime now, LocalDate today) {
+    private void deleteV2Routine(User user, Long v2RoutineId, LocalDate today) {
         RoutineV2 routineV2 = routineV2Repository.findByUserAndRoutineId(user, v2RoutineId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE));
 
@@ -285,7 +285,12 @@ public class RoutineService {
         // 오늘 이후 루틴 내역 모두 삭제 (Hard Delete)
         List<RoutineV2> routinesV2AfterToday = routineV2Repository
             .findByRoutineInfoAndRoutineDateAfter(routineInfoV2, today);
-        routineV2Repository.deleteAll(routinesV2AfterToday);
+
+        List<Long> routineIds = routinesV2AfterToday.stream()
+            .map(RoutineV2::getRoutineId)
+            .toList();
+
+        routineV2Repository.deleteAllPhysicallyByIds(routineIds); // 물리 삭제
 
         routineInfoV2.updateRoutineEndDate(today); // 종료 일자를 삭제 당일로 변경
         routineInfoV2.updateRoutineDeletedYn(true); // 루틴 삭제 여부 갱신

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -40,6 +40,9 @@ import bitnagil.bitnagil_backend.routine.repository.SubRoutineRepository;
 import bitnagil.bitnagil_backend.routine.request.RegisterRoutineRequest;
 import bitnagil.bitnagil_backend.routine.request.SubRoutineInfo;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineRequest;
+import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
+import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
+import bitnagil.bitnagil_backend.routineV2.repository.RoutineV2Repository;
 import bitnagil.bitnagil_backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,6 +66,7 @@ public class RoutineService {
     private final RoutineFactory routineFactory;
     private final RoutineMapper routineMapper;
     private final ChangedRoutineFactory changedRoutineFactory;
+    private final RoutineV2Repository routineV2Repository;
 
     // 루틴, 세부루틴을 함께 저장하는 루틴 등록 메서드
     @Transactional
@@ -157,24 +161,20 @@ public class RoutineService {
         }
     }
 
-    // 루틴, 세부 루틴을 삭제하는 메서드
+    // 루틴을 모든 날짜에서 삭제하는 메서드
     @Transactional
-    public void deleteRoutine(User user, UUID routineId) {
+    public void deleteRoutine(User user, String routineId) {
+        LocalDate today = LocalDate.now();
         LocalDateTime now = LocalDateTime.now();
 
-        Routine routine = routineValidator.validateRoutineOwnership(routineId, user, now);
-
-        // 기존 루틴, 서브 루틴의 이력 종료일시 및 deleteAt 갱신
-        routine.updateHistoryEndDateTime(now);
-        routine.setDeleteAt(now);
-
-        // 서브 루틴을 순회하면서 이력 종료일시 및 deleteAt 갱신
-        subRoutineRepository.findByRoutineId(routineId)
-            .forEach(subRoutine -> {
-                subRoutine.updateHistoryEndDateTime(now);
-                subRoutine.setDeleteAt(now);
-            });
-
+        if (routineId.length() == 36) { // (v1) routineId의 타입이 UUID인 경우
+            UUID v1RoutineId = UUID.fromString(routineId);
+            deleteV1Routine(user, v1RoutineId, now);
+        }
+        else { // (v2) routineId의 타입이 Long인 경우
+            Long v2RoutineId = Long.valueOf(routineId);
+            deleteV2Routine(user, v2RoutineId, now, today);
+        }
     }
 
     // 유저가 선택한 요일(당일)만 루틴, 서브 루틴을 삭제하는 메서드
@@ -271,6 +271,40 @@ public class RoutineService {
                 routineCompletionRepository.save(newRoutineCompletion);
             }
         }
+    }
+
+    // v2에서 사용하는 루틴 삭제 메서드
+    private void deleteV2Routine(User user, Long v2RoutineId, LocalDateTime now, LocalDate today) {
+        RoutineV2 routineV2 = routineV2Repository.findById(v2RoutineId)
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE));
+
+        RoutineInfoV2 routineInfoV2 = routineV2.getRoutineInfo();
+
+        if (!routineInfoV2.getUser().getUserId().equals(user.getUserId())) { // 로그인한 유저가 등록한 루틴이 아닌 경우
+            throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
+        }
+        routineInfoV2.setDeleteAt(now); // 루틴 정보 삭제 (Sort Delete)
+
+        // 오늘 이후 루틴 내역 모두 삭제 (Hard Delete)
+        List<RoutineV2> routinesV2AfterToday = routineV2Repository
+            .findByRoutineInfoAndRoutineDateAfter(routineInfoV2, today);
+        routineV2Repository.deleteAll(routinesV2AfterToday);
+    }
+
+    // v1에서 사용하는 루틴 삭제 메서드
+    private void deleteV1Routine(User user, UUID v1RoutineId, LocalDateTime now) {
+        Routine routine = routineValidator.validateRoutineOwnership(v1RoutineId, user, now);
+
+        // 기존 루틴, 서브 루틴의 이력 종료일시 및 deleteAt 갱신
+        routine.updateHistoryEndDateTime(now);
+        routine.setDeleteAt(now);
+
+        // 서브 루틴을 순회하면서 이력 종료일시 및 deleteAt 갱신
+        subRoutineRepository.findByRoutineId(v1RoutineId)
+            .forEach(subRoutine -> {
+                subRoutine.updateHistoryEndDateTime(now);
+                subRoutine.setDeleteAt(now);
+            });
     }
 
     // routineCompletionId에 해당하는 완료 여부 데이터 삭제

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -285,6 +285,8 @@ public class RoutineService {
         if (!isMatchedUserAndRoutine(user, routineInfoV2)) {
             throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
         }
+
+        routineInfoV2.updateRoutineEndDate(today); // 종료 일자를 삭제 당일로 변경
         routineInfoV2Repository.delete(routineInfoV2); // 루틴 정보 삭제 (Sort Delete)
 
         // 오늘 이후 루틴 내역 모두 삭제 (Hard Delete)

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -277,14 +277,10 @@ public class RoutineService {
 
     // v2에서 사용하는 루틴 삭제 메서드
     private void deleteV2Routine(User user, Long v2RoutineId, LocalDateTime now, LocalDate today) {
-        RoutineV2 routineV2 = routineV2Repository.findById(v2RoutineId)
+        RoutineV2 routineV2 = routineV2Repository.findByUserAndRoutineId(user, v2RoutineId)
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE));
 
         RoutineInfoV2 routineInfoV2 = routineV2.getRoutineInfo();
-
-        if (!isMatchedUserAndRoutine(user, routineInfoV2)) {
-            throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
-        }
 
         // 오늘 이후 루틴 내역 모두 삭제 (Hard Delete)
         List<RoutineV2> routinesV2AfterToday = routineV2Repository
@@ -292,12 +288,7 @@ public class RoutineService {
         routineV2Repository.deleteAll(routinesV2AfterToday);
 
         routineInfoV2.updateRoutineEndDate(today); // 종료 일자를 삭제 당일로 변경
-        routineInfoV2Repository.delete(routineInfoV2); // 루틴 정보 삭제 (Sort Delete)
-    }
-
-    // 로그인한 유저가 등록한 루틴인지 검증하는 로직
-    private static boolean isMatchedUserAndRoutine(User user, RoutineInfoV2 routineInfoV2) {
-        return routineInfoV2.getUser().getUserId().equals(user.getUserId());
+        routineInfoV2.updateRoutineDeletedYn(true); // 루틴 삭제 여부 갱신
     }
 
     // v1에서 사용하는 루틴 삭제 메서드

--- a/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/service/RoutineService.java
@@ -41,6 +41,7 @@ import bitnagil.bitnagil_backend.routine.request.RegisterRoutineRequest;
 import bitnagil.bitnagil_backend.routine.request.SubRoutineInfo;
 import bitnagil.bitnagil_backend.routine.request.UpdateRoutineRequest;
 import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
+import bitnagil.bitnagil_backend.routineInfoV2.repository.RoutineInfoV2Repository;
 import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
 import bitnagil.bitnagil_backend.routineV2.repository.RoutineV2Repository;
 import bitnagil.bitnagil_backend.user.domain.User;
@@ -67,6 +68,7 @@ public class RoutineService {
     private final RoutineMapper routineMapper;
     private final ChangedRoutineFactory changedRoutineFactory;
     private final RoutineV2Repository routineV2Repository;
+    private final RoutineInfoV2Repository routineInfoV2Repository;
 
     // 루틴, 세부루틴을 함께 저장하는 루틴 등록 메서드
     @Transactional
@@ -280,15 +282,20 @@ public class RoutineService {
 
         RoutineInfoV2 routineInfoV2 = routineV2.getRoutineInfo();
 
-        if (!routineInfoV2.getUser().getUserId().equals(user.getUserId())) { // 로그인한 유저가 등록한 루틴이 아닌 경우
+        if (!isMatchedUserAndRoutine(user, routineInfoV2)) {
             throw new CustomException(ErrorCode.ROUTINE_USER_NOT_MATCHED);
         }
-        routineInfoV2.setDeleteAt(now); // 루틴 정보 삭제 (Sort Delete)
+        routineInfoV2Repository.delete(routineInfoV2); // 루틴 정보 삭제 (Sort Delete)
 
         // 오늘 이후 루틴 내역 모두 삭제 (Hard Delete)
         List<RoutineV2> routinesV2AfterToday = routineV2Repository
             .findByRoutineInfoAndRoutineDateAfter(routineInfoV2, today);
         routineV2Repository.deleteAll(routinesV2AfterToday);
+    }
+
+    // 로그인한 유저가 등록한 루틴인지 검증하는 로직
+    private static boolean isMatchedUserAndRoutine(User user, RoutineInfoV2 routineInfoV2) {
+        return routineInfoV2.getUser().getUserId().equals(user.getUserId());
     }
 
     // v1에서 사용하는 루틴 삭제 메서드

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
@@ -2,6 +2,7 @@ package bitnagil.bitnagil_backend.routineInfoV2.domain;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -30,7 +31,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@SQLDelete(sql = "UPDATE routine_info_v2 SET deleted_at = NOW() WHERE routine_info_id = ?")
+@SQLDelete(sql = "UPDATE routine_infov2 SET deleted_at = NOW() WHERE routine_info_id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class RoutineInfoV2 extends BaseTimeEntity {
     @Id
@@ -66,5 +67,9 @@ public class RoutineInfoV2 extends BaseTimeEntity {
         this.routineStartDate = routineStartDate;
         this.routineEndDate = routineEndDate;
         this.user = user;
+    }
+
+    public void setDeleteAt(LocalDateTime deleteAt) {
+        this.deletedAt = deleteAt;
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
@@ -68,4 +68,8 @@ public class RoutineInfoV2 extends BaseTimeEntity {
         this.routineEndDate = routineEndDate;
         this.user = user;
     }
+
+    public void updateRoutineEndDate(LocalDate routineEndDate) {
+        this.routineEndDate = routineEndDate;
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
@@ -68,8 +68,4 @@ public class RoutineInfoV2 extends BaseTimeEntity {
         this.routineEndDate = routineEndDate;
         this.user = user;
     }
-
-    public void setDeleteAt(LocalDateTime deleteAt) {
-        this.deletedAt = deleteAt;
-    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
@@ -2,7 +2,6 @@ package bitnagil.bitnagil_backend.routineInfoV2.domain;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -54,22 +53,30 @@ public class RoutineInfoV2 extends BaseTimeEntity {
     @NotNull
     private LocalDate routineEndDate; // 루틴 종료 일자
 
+    @NotNull
+    private Boolean routineDeletedYn; // 루틴 삭제 여부
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // 루틴의 주체인 유저
 
     @Builder
     public RoutineInfoV2(String routineName, List<DayOfWeek> routineRepeatDay, LocalTime routineExecutionTime,
-        LocalDate routineStartDate, LocalDate routineEndDate, User user) {
+        LocalDate routineStartDate, LocalDate routineEndDate, Boolean routineDeletedYn, User user) {
         this.routineName = routineName;
         this.routineRepeatDay = routineRepeatDay;
         this.routineExecutionTime = routineExecutionTime;
         this.routineStartDate = routineStartDate;
         this.routineEndDate = routineEndDate;
+        this.routineDeletedYn = routineDeletedYn;
         this.user = user;
     }
 
     public void updateRoutineEndDate(LocalDate routineEndDate) {
         this.routineEndDate = routineEndDate;
+    }
+
+    public void updateRoutineDeletedYn(Boolean routineDeletedYn) {
+        this.routineDeletedYn = routineDeletedYn;
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/service/RoutineInfoV2Factory.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/service/RoutineInfoV2Factory.java
@@ -25,6 +25,7 @@ public class RoutineInfoV2Factory {
                 .routineExecutionTime(routineExecutionTime)
                 .routineStartDate(routineStartDate)
                 .routineEndDate(routineEndDate)
+                .routineDeletedYn(false)
                 .user(user)
                 .build();
     }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
@@ -29,7 +29,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@SQLDelete(sql = "DELETE FROM routinev2 WHERE routine_id = ?")
+@SQLDelete(sql = "UPDATE routine_v2 SET deleted_at = NOW() WHERE routine_id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class RoutineV2 extends BaseTimeEntity {
     @Id

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
@@ -29,7 +29,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@SQLDelete(sql = "UPDATE routine_v2 SET deleted_at = NOW() WHERE routine_id = ?")
+@SQLDelete(sql = "UPDATE routinev2 SET deleted_at = NOW() WHERE routine_id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class RoutineV2 extends BaseTimeEntity {
     @Id

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
@@ -29,7 +29,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@SQLDelete(sql = "UPDATE routinev2 SET deleted_at = NOW() WHERE routine_id = ?")
+@SQLDelete(sql = "DELETE FROM routinev2 WHERE routine_id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class RoutineV2 extends BaseTimeEntity {
     @Id

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
@@ -4,6 +4,7 @@ import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
 import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
 import bitnagil.bitnagil_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -47,4 +48,12 @@ public interface RoutineV2Repository extends JpaRepository<RoutineV2, Long> {
 
     // 오늘 이후의 루틴 정보에 맞는 루틴 내역을 조회
     List<RoutineV2> findByRoutineInfoAndRoutineDateAfter(RoutineInfoV2 routineInfoV2, LocalDate date);
+
+    /**
+     *  루틴을 물리 삭제하기 위한 JPQL
+     *  메모리 로드 비용 줄이기 위해 routineIds를 파라미터로 채택
+     */
+    @Modifying
+    @Query("DELETE FROM RoutineV2 r WHERE r.routineId IN :ids")
+    void deleteAllPhysicallyByIds(@Param("ids") List<Long> routineIds);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/repository/RoutineV2Repository.java
@@ -1,5 +1,9 @@
 package bitnagil.bitnagil_backend.routineV2.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
 import bitnagil.bitnagil_backend.routineV2.domain.RoutineV2;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RoutineV2Repository extends JpaRepository<RoutineV2, Long> {
 
+    // 오늘 이후의 루틴 내역을 조회
+    List<RoutineV2> findByRoutineInfoAndRoutineDateAfter(RoutineInfoV2 routineInfoV2, LocalDate date);
 }

--- a/src/main/resources/db/migration/V6__add_routine_deleted_yn_to_routine_info_v2.sql
+++ b/src/main/resources/db/migration/V6__add_routine_deleted_yn_to_routine_info_v2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE routine_infov2
+    ADD COLUMN routine_deleted_yn BIT(1) NOT NULL DEFAULT b'0'


### PR DESCRIPTION
## 작업 내역
- 기존 루틴 삭제 API가 v2인 Long 타입의 routineId도 호환될 수 있도록 요청 타입을 기존 UUID에서 String으로 변경
- 이에 따라 서비스 로직에서 string.length()를 통해 분기 처리 수행
- v2에 대한 삭제 로직 추가
- RoutineV2, RoutineInfoV2 엔티티의 @SQLDelete의 SQL문 수정

## 고민한 사항
1. 저희가 사용하는 하이푼을 포함한 UUID의 길이는 36이기 때문에 이 조건으로 분기처리를 하였습니다. if, if-else, else 구조로 처리하지 않은 이유는 클라이언트가 가지고 있는 routineId는 DB에서 받은 값으로 1차적으로 정합성이 유지되고, Long 타입의 길이는 유동적이기 때문에 36의 길이가 아닌 모든 경우는 Long으로 간주하였습니다. (앱 유저가 악의적으로 다른 툴을 사용하여 API 요청 데이터를 변조할 가능성이 희박하다고 판단.)
2. 현재 RoutineV2의 delete sql을 호출하면 soft delete를 시키도록 설정되어 있습니다. 하지만 유저가 해당 루틴을 삭제하면 삭제 당일을 포함한 과거의 기록은 필요하지만 미래의 데이터는 모두 동일한 상태로 아무 곳에서 쓰지 않는 고아 상태의 데이터가 됩니다. 그래서 이 경우에는 soft delete가 아닌 hard delete를 통해 불필요한 데이터 저장을 방지하는 것이 어떨까 하는 고민이 있었습니다.

## 리뷰 요청사항
- 전반적인 변경 사항을 검토해주세요!
- 고민 사항을 읽어보시고 이에 대해 피드백 부탁드립니다!
- 현재 DB에서는 routinev2, routine_infov2 이렇게 테이블 명이 잡혀 있어서 각 엔티티의 @SQLDelete의 SQL문 변경했는데 괜찮은지 피드백 부탁드립니다!