### PR TITLE
[T3-164] 루틴 완료 여부 갱신 API

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/routine/controller/spec/RoutineSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routine/controller/spec/RoutineSpec.java
@@ -39,7 +39,7 @@ public interface RoutineSpec {
         ErrorCode.ROUTINE_USER_NOT_MATCHED})
     CustomResponseDto<Object> updateRoutine(User user, UpdateRoutineRequest updateRoutineRequest);
 
-    @Operation(summary = "루틴 및 서브 루틴을 모두 삭제합니다.")
+    @Operation(summary = "(V2) 모든 날짜에서 루틴을 삭제합니다. (루틴 전체 삭제)")
     @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_ROUTINE, ErrorCode.ROUTINE_USER_NOT_MATCHED})
     CustomResponseDto<Object> deleteRoutine(User user, String routineId);
 

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/RoutineV2Controller.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/RoutineV2Controller.java
@@ -1,5 +1,6 @@
 package bitnagil.bitnagil_backend.routineV2.controller;
 
+import bitnagil.bitnagil_backend.routineV2.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
 import jakarta.validation.constraints.NotNull;
@@ -43,4 +44,18 @@ public class RoutineV2Controller implements RoutineV2Spec {
 
         return CustomResponseDto.from(null);
     }
+
+    /*
+     * 루틴 완료 여부를 갱신하는 API 입니다.
+     * 멱등성이 보장되는 업데이트 API이므로 PUT Method를 사용했습니다.
+     */
+    @PutMapping("")
+    public CustomResponseDto<Object> updateRoutineCompletionStatus(
+        @CurrentUser User user, @RequestBody UpdateRoutineCompletionRequest request) {
+
+        routineV2Service.updateRoutineCompletionStatus(user, request);
+
+        return CustomResponseDto.from(null);
+    }
+
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
@@ -40,7 +40,7 @@ public interface RoutineV2Spec {
     @Operation(summary = "루틴 정보 등록 및 루틴 시작, 종료일자 사이에서 반복요일에 해당하는 날짜로 루틴 데이터를 생성합니다.")
     CustomResponseDto<Object> registerRoutine(User user, RegisterRoutineV2Request request);
 
-    @Operation(summary = "루틴 완료 여부를 갱신합니다. (여러 루틴의 완료 여부를 리스트로 만들어 요청하는 방식입니다.)")
+    @Operation(summary = "여러 루틴의 완료 여부를 갱신합니다. (여러 루틴의 완료 여부를 리스트로 만들어 요청하는 방식입니다.)")
     @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_ROUTINE})
     CustomResponseDto<Object> updateRoutineCompletionStatus(
         @CurrentUser User user, @RequestBody UpdateRoutineCompletionRequest request);

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/controller/spec/RoutineV2Spec.java
@@ -1,10 +1,12 @@
 package bitnagil.bitnagil_backend.routineV2.controller.spec;
 
+import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
 import bitnagil.bitnagil_backend.global.swagger.ApiErrorCodeExamples;
 import bitnagil.bitnagil_backend.global.swagger.ApiTags;
 import bitnagil.bitnagil_backend.routineV2.request.RegisterRoutineV2Request;
+import bitnagil.bitnagil_backend.routineV2.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
 import bitnagil.bitnagil_backend.user.domain.User;
@@ -16,6 +18,8 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 import java.util.UUID;
+
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = ApiTags.ROUTINEV2)
 public interface RoutineV2Spec {
@@ -35,4 +39,9 @@ public interface RoutineV2Spec {
 
     @Operation(summary = "루틴 정보 등록 및 루틴 시작, 종료일자 사이에서 반복요일에 해당하는 날짜로 루틴 데이터를 생성합니다.")
     CustomResponseDto<Object> registerRoutine(User user, RegisterRoutineV2Request request);
+
+    @Operation(summary = "루틴 완료 여부를 갱신합니다. (여러 루틴의 완료 여부를 리스트로 만들어 요청하는 방식입니다.)")
+    @ApiErrorCodeExamples({ErrorCode.NOT_FOUND_ROUTINE})
+    CustomResponseDto<Object> updateRoutineCompletionStatus(
+        @CurrentUser User user, @RequestBody UpdateRoutineCompletionRequest request);
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/domain/RoutineV2.java
@@ -63,4 +63,10 @@ public class RoutineV2 extends BaseTimeEntity {
         this.subRoutineCompleteYn = subRoutineCompleteYn;
         this.routineInfo = routineInfo;
     }
+
+    // 루틴 완료 여부 갱신
+    public void updateRoutineCompleteYn(Boolean routineCompleteYn, List<Boolean> subRoutineCompleteYn) {
+        this.routineCompleteYn = routineCompleteYn;
+        this.subRoutineCompleteYn = subRoutineCompleteYn;
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/request/UpdateRoutineCompletionInfo.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/request/UpdateRoutineCompletionInfo.java
@@ -1,0 +1,31 @@
+package bitnagil.bitnagil_backend.routineV2.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateRoutineCompletionInfo {
+
+    @Schema(description = "루틴 완료 여부를 갱신할 루틴 ID 값입니다.",
+            example = "4",
+            required = true)
+    @NotNull
+    private Long routineId;
+
+    @Schema(description = "메인 루틴의 완료 여부입니다.",
+            example = "true",
+            required = true)
+    @NotNull
+    private Boolean routineCompleteYn;
+
+    @Schema(description = "서브루틴 완료 여부 리스트입니다..",
+            example = "[true, false, true]",
+            required = true)
+    @NotNull
+    private List<Boolean> subRoutineCompleteYn;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/request/UpdateRoutineCompletionInfo.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/request/UpdateRoutineCompletionInfo.java
@@ -23,7 +23,7 @@ public class UpdateRoutineCompletionInfo {
     @NotNull
     private Boolean routineCompleteYn;
 
-    @Schema(description = "서브루틴 완료 여부 리스트입니다..",
+    @Schema(description = "서브루틴 완료 여부 리스트입니다.",
             example = "[true, false, true]",
             required = true)
     @NotNull

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/request/UpdateRoutineCompletionRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/request/UpdateRoutineCompletionRequest.java
@@ -1,0 +1,19 @@
+package bitnagil.bitnagil_backend.routineV2.request;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "루틴 완료 여부 갱신 DTO")
+public class UpdateRoutineCompletionRequest {
+
+    @Schema(description = "루틴 완료 여부를 갱신할 루틴 정보 리스트입니다.",
+            required = true)
+    @NotNull
+    List<UpdateRoutineCompletionInfo> routineCompletionInfos;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -6,6 +6,8 @@ import java.util.*;
 
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
+import bitnagil.bitnagil_backend.routineV2.request.UpdateRoutineCompletionInfo;
+import bitnagil.bitnagil_backend.routineV2.request.UpdateRoutineCompletionRequest;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResponse;
 import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
 import org.springframework.stereotype.Service;
@@ -99,6 +101,18 @@ public class RoutineV2Service {
             .toList();
 
         routineV2Repository.saveAll(routinesToRegister);
+    }
+
+    // 루틴 완료 여부를 업데이트 하는 메서드
+    @Transactional
+    public void updateRoutineCompletionStatus(User user, UpdateRoutineCompletionRequest request) {
+        for (UpdateRoutineCompletionInfo info : request.getRoutineCompletionInfos()) {
+            RoutineV2 routineV2 = routineV2Repository.findByUserAndRoutineId(user, info.getRoutineId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROUTINE));
+
+            // 루틴, 서브루틴 완료 여부 갱신
+            routineV2.updateRoutineCompleteYn(info.getRoutineCompleteYn(), info.getSubRoutineCompleteYn());
+        }
     }
 
     /**


### PR DESCRIPTION
## 작업 내역
- 루틴 완료 여부 API 추가

## 고민한 사항
- 서브 루틴 완료 여부를 Map<String, Boolean> 타입을 통해 서브루틴 이름과 완료 여부를 직접 매핑하려고 했지만, 유저가 같은 이름의 서브 루틴을 등록 시 식별할 수 없게 됩니다. 그래서 초기에 List<String>, List<Boolean>을 통해 이름과 완료 여부를 매핑되게 설정했기 때문에 서브 루틴 완료 여부만 업데이트 하면 되겠다고 판단했습니다.
또한 List<Boolean>의 내부 요소에 직접 접근하여 업데이트하는 경우에는 더티 체킹이 되지 않지만, List<Boolean> subRoutineCompleteYn의 리스트 참조 자체는 더티 체킹의 범위 내에 있기 때문에 문제 없이 동작합니다.

## 리뷰 요청사항
- 복잡한 로직은 없어서 전반적으로 검토 부탁드립니다.