### PR TITLE
[T3-162] 홈 루틴 조회 시 일자별 루틴전체 완료 구분값 추가

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/EmotionMarbleController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/emotionMarble/controller/EmotionMarbleController.java
@@ -39,7 +39,7 @@ public class EmotionMarbleController implements EmotionMarbleSpec {
     }
 
     // todo: 당일의 유저가 선택한 감정 구슬 조회 API V2로 변환
-    @GetMapping("/v2/{searchDate}")
+    @GetMapping("/v2/emotion-marbles/{searchDate}")
     public CustomResponseDto<EmotionMarbleTypeResponseV2> getEmotionMarbleBySearchDateV2(
             @CurrentUser User user,
             @PathVariable LocalDate searchDate) {
@@ -50,7 +50,7 @@ public class EmotionMarbleController implements EmotionMarbleSpec {
     // 당일의 유저가 선택한 감정 구슬 조회 API
     // TODO: v2로 전환 시 deprecated 처리
     @Deprecated()
-    @GetMapping("/v1/{searchDate}")
+    @GetMapping("/v1/emotion-marbles/{searchDate}")
     public CustomResponseDto<EmotionMarbleTypeResponse> getEmotionMarbleBySearchDate(
         @CurrentUser User user,
         @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate searchDate) {

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/domain/RoutineInfoV2.java
@@ -7,15 +7,9 @@ import java.util.List;
 
 import bitnagil.bitnagil_backend.global.entity.BaseTimeEntity;
 import bitnagil.bitnagil_backend.global.utils.DayOfWeekConverter;
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.enums.RecommendedRoutineType;
 import bitnagil.bitnagil_backend.user.domain.User;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -56,13 +50,18 @@ public class RoutineInfoV2 extends BaseTimeEntity {
     @NotNull
     private Boolean routineDeletedYn; // 루틴 삭제 여부
 
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(40)")
+    private RecommendedRoutineType recommendedRoutineType; // 추천 루틴 타입
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // 루틴의 주체인 유저
 
     @Builder
     public RoutineInfoV2(String routineName, List<DayOfWeek> routineRepeatDay, LocalTime routineExecutionTime,
-        LocalDate routineStartDate, LocalDate routineEndDate, Boolean routineDeletedYn, User user) {
+        LocalDate routineStartDate, LocalDate routineEndDate, Boolean routineDeletedYn, User user,
+        RecommendedRoutineType recommendedRoutineType) {
         this.routineName = routineName;
         this.routineRepeatDay = routineRepeatDay;
         this.routineExecutionTime = routineExecutionTime;
@@ -70,6 +69,7 @@ public class RoutineInfoV2 extends BaseTimeEntity {
         this.routineEndDate = routineEndDate;
         this.routineDeletedYn = routineDeletedYn;
         this.user = user;
+        this.recommendedRoutineType = recommendedRoutineType;
     }
 
     public void updateRoutineEndDate(LocalDate routineEndDate) {

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/response/RoutineV2SearchResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/response/RoutineV2SearchResponse.java
@@ -14,5 +14,20 @@ import java.util.Map;
 @Builder
 public class RoutineV2SearchResponse {
     @Schema(description = "날짜(LocalDate: 2025-08-01)와 같은 형태를 key로 가지는 루틴 목록 Map입니다. Swagger에서는 additionalProp1처럼 보일 수 있습니다.")
-    private Map<LocalDate, List<RoutineV2SearchResultDto>> routines; // 날짜별 루틴 목록
+    private Map<LocalDate, RoutineData> routines; // 날짜별 루틴 목록
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class RoutineData {
+        @Schema(description = "날짜별 루틴 목록")
+        private List<RoutineV2SearchResultDto> routineList;
+
+        @Schema(description = "해당 날짜 모든 루틴이 완료되었는지 여부")
+        private boolean allCompleted;
+
+        public void setAllCompleted(boolean allCompleted) {
+            this.allCompleted = allCompleted;
+        }
+    }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/response/RoutineV2SearchResultDto.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/response/RoutineV2SearchResultDto.java
@@ -1,5 +1,6 @@
 package bitnagil.bitnagil_backend.routineV2.response;
 
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.enums.RecommendedRoutineType;
 import bitnagil.bitnagil_backend.routine.domain.enums.RoutineType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -31,4 +32,6 @@ public class RoutineV2SearchResultDto {
     private List<String> subRoutineNames;
     @Schema(example = "[true, false]")
     private List<Boolean> subRoutineCompleteYn;
+    @Schema(example = "WAKE_UP")
+    private RecommendedRoutineType recommendedRoutineType;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Mapper.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Mapper.java
@@ -29,7 +29,7 @@ public class RoutineV2Mapper {
                 .build();
     }
 
-    public RoutineV2SearchResponse toRoutineV2SearchResponse(Map<LocalDate, List<RoutineV2SearchResultDto>> response) {
+    public RoutineV2SearchResponse toRoutineV2SearchResponse(Map<LocalDate, RoutineV2SearchResponse.RoutineData> response) {
         return RoutineV2SearchResponse.builder()
                 .routines(response)
                 .build();

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Mapper.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Mapper.java
@@ -6,7 +6,6 @@ import bitnagil.bitnagil_backend.routineV2.response.RoutineV2SearchResultDto;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 
 
@@ -26,6 +25,7 @@ public class RoutineV2Mapper {
                 .routineCompleteYn(routine.getRoutineCompleteYn())
                 .subRoutineNames(routine.getSubRoutineNames())
                 .subRoutineCompleteYn(routine.getSubRoutineCompleteYn())
+                .recommendedRoutineType(routine.getRoutineInfo().getRecommendedRoutineType())
                 .build();
     }
 

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -118,7 +118,7 @@ public class RoutineV2Service {
 
     // 특정 기간 보유 루틴 조회
     private RoutineV2SearchResponse queryRoutines(User user, LocalDate startDate, LocalDate endDate) {
-        Map<LocalDate, List<RoutineV2SearchResultDto>> response = new HashMap<>();
+        Map<LocalDate, RoutineV2SearchResponse.RoutineData> response = new HashMap<>();
 
         List<RoutineV2> routineList = routineV2Repository.findByUserAndDateRange(user, startDate, endDate);
 
@@ -126,12 +126,26 @@ public class RoutineV2Service {
             LocalDate date = routineV2.getRoutineDate();
             RoutineV2SearchResultDto routineSearchResultDto = routineV2Mapper.toRoutineV2SearchResultDto(routineV2);
 
-            // 날짜별 리스트에 추가
-            response.computeIfAbsent(date, key -> new ArrayList<>()).add(routineSearchResultDto);
+            // 날짜별 RoutineData 생성 혹은 가져오기
+            response.computeIfAbsent(date, key -> RoutineV2SearchResponse.RoutineData.builder()
+                    .routineList(new ArrayList<>())
+                    .allCompleted(true) // 초기값 true
+                    .build());
+
+            RoutineV2SearchResponse.RoutineData routineData = response.get(date);
+
+            // 리스트에 추가
+            routineData.getRoutineList().add(routineSearchResultDto);
+
+            // 하나라도 완료 안 된 루틴이 있으면 false로 변경
+            if (!routineSearchResultDto.getRoutineCompleteYn()) {
+                routineData.setAllCompleted(false);
+            }
         }
 
-        response.forEach((date, routineSearchResultDto) ->
-                routineSearchResultDto.sort(Comparator.comparing(RoutineV2SearchResultDto::getExecutionTime))
+        // 정렬 처리
+        response.values().forEach(data ->
+                data.getRoutineList().sort(Comparator.comparing(RoutineV2SearchResultDto::getExecutionTime))
         );
 
         return routineV2Mapper.toRoutineV2SearchResponse(response);

--- a/src/main/resources/db/migration/V7__add_recommended_routine_type_to_routine_infov2.sql
+++ b/src/main/resources/db/migration/V7__add_recommended_routine_type_to_routine_infov2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE routine_infov2
+    ADD COLUMN recommended_routine_type VARCHAR(40) NULL;


### PR DESCRIPTION
## 작업 내역
- 홈화면에서 조회기간에 따른 루틴 조회 시 각 날짜에 해당하는 루틴의 전체 완료 여부에 따른 응답값 추가
## 고민한 사항
- RoutineV2SearchResponse 클래스에 전체 루틴 완료여부값이 생김에 따라 inner class 형태로 구조를 변경했습니다.
## 리뷰 요청사항
- 간단한 로직이니 확인한번 부탁드릴게요