### PR TITLE
[T3-166] 추천루틴 조회 응답값에 추천 루틴 타입 추가 및 루틴 등록시 요청값에 추천 루틴 추가

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/onboarding/service/OnboardingService.java
@@ -114,6 +114,7 @@ public class OnboardingService {
                     recommendedRoutine.getExecutionTime(),
                     today,
                     today,
+                    recommendedRoutine.getRecommendedRoutineType(),
                     user
             );
 

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/response/RecommendedRoutineSearchResult.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/response/RecommendedRoutineSearchResult.java
@@ -1,6 +1,7 @@
 package bitnagil.bitnagil_backend.recommendedRoutine.response;
 
 import bitnagil.bitnagil_backend.recommendedRoutine.domain.enums.RecommendedRoutineLevel;
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.enums.RecommendedRoutineType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,6 +29,8 @@ public class RecommendedRoutineSearchResult {
     // 추천 루틴 수행 시간
     @Schema(description = "추천 루틴 수행 시간", example = "08:00:00")
     private LocalTime executionTime; // HH:mm 형식으로 변환된 수행 시간
+    @Schema(description = "추천 루틴 타입", example = "WAKE_UP")
+    private RecommendedRoutineType recommendedRoutineType;
     // 추천 서브 루틴 리스트
     private List<RecommendedSubRoutineSearchResult> recommendedSubRoutineSearchResult;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineMapper.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineMapper.java
@@ -43,6 +43,7 @@ public class RecommendedRoutineMapper {
             .recommendedRoutineLevel(recommendedRoutine.getRecommendedRoutineLevel())
             .executionTime(recommendedRoutine.getExecutionTime())
             .recommendedSubRoutineSearchResult(recommendedSubRoutineResults)
+            .recommendedRoutineType(recommendedRoutine.getRecommendedRoutineType())
             .build();
     }
 

--- a/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/service/RoutineInfoV2Factory.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineInfoV2/service/RoutineInfoV2Factory.java
@@ -1,5 +1,6 @@
 package bitnagil.bitnagil_backend.routineInfoV2.service;
 
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.enums.RecommendedRoutineType;
 import bitnagil.bitnagil_backend.routineInfoV2.domain.RoutineInfoV2;
 import bitnagil.bitnagil_backend.user.domain.User;
 import org.springframework.stereotype.Component;
@@ -18,7 +19,8 @@ public class RoutineInfoV2Factory {
     // 신규 RoutineInfo 엔티티 생성 및 초기화
     public RoutineInfoV2 createNewRoutineInfo(String routineName, List<DayOfWeek> routineRepeatDay,
                                         LocalTime routineExecutionTime, LocalDate routineStartDate,
-                                        LocalDate routineEndDate, User user) {
+                                        LocalDate routineEndDate, RecommendedRoutineType recommendedRoutineType,
+                                        User user) {
         return RoutineInfoV2.builder()
                 .routineName(routineName)
                 .routineRepeatDay(routineRepeatDay) // 온보딩은 반복일자를 설정하지 않는다.
@@ -27,6 +29,7 @@ public class RoutineInfoV2Factory {
                 .routineEndDate(routineEndDate)
                 .routineDeletedYn(false)
                 .user(user)
+                .recommendedRoutineType(recommendedRoutineType)
                 .build();
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/request/RegisterRoutineV2Request.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/request/RegisterRoutineV2Request.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.enums.RecommendedRoutineType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -48,4 +49,7 @@ public class RegisterRoutineV2Request {
     @Schema(description = "세부 루틴 이름에 대한 리스트입니다.",
         example = "[\"손 씻기\", \"세수 하기\", \"양치 하기\"]")
     private List<String> subRoutineName;
+
+    @Schema(description = "추천 루틴 타입입니다.", example = "WAKE_UP")
+    private RecommendedRoutineType recommendedRoutineType;
 }

--- a/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
+++ b/src/main/java/bitnagil/bitnagil_backend/routineV2/service/RoutineV2Service.java
@@ -72,6 +72,7 @@ public class RoutineV2Service {
             request.getExecutionTime(),
             request.getRoutineStartDate(),
             request.getRoutineEndDate(),
+            request.getRecommendedRoutineType(),
             user);
 
         routineInfoV2Repository.save(routineInfo);


### PR DESCRIPTION
## 작업 내역
- 다수의 서비스 및 요청 응답에 추천 루틴 타입 추가
- OnboardingService의 registrationRoutinesV2 메서드 RoutineInfoV2 저장 시 추천 루틴 타입 추가
- 추천 루틴 조회, 단건 조회 시 루틴응답에 추천 루틴 타입 추가
- RoutineInfoV2 생성시 추천 루틴 타입 추가
- 루틴 등록 시 요청 값에 추천 루틴 타입 추가
## 고민한 사항

## 리뷰 요청사항