### PR TITLE
[T3-161] 추천 루틴 조회 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 	// flyway
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
+
+	// cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/bitnagil/bitnagil_backend/global/config/CacheConfig.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/config/CacheConfig.java
@@ -1,0 +1,91 @@
+package bitnagil.bitnagil_backend.global.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    /**
+     * Jackson 직렬화 문제 해결을 위한 ObjectMapper 커스터마이징
+     * Redis Cache 전용 ObjectMapper (전역 빈 아님)
+     */
+    private ObjectMapper createRedisObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new ParameterNamesModule());
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(
+                objectMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.EVERYTHING,
+                JsonTypeInfo.As.WRAPPER_OBJECT
+        );
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // Redis 전용이므로 FEIGN, RestTemplate 등에 영향 없음
+        return objectMapper;
+    }
+
+    /**
+     * Spring Boot 가 기본적으로 RedisCacheManager 를 자동 설정해줘서 RedisCacheConfiguration 없어도 사용 가능
+     * Bean 을 새로 선언하면 직접 설정한 RedisCacheConfiguration 이 적용
+     */
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        ObjectMapper redisObjectMapper = createRedisObjectMapper();
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                )
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper))
+                );
+    }
+
+    /**
+     * 여러 Redis Cache 에 관한 설정을 하고 싶다면 RedisCacheManagerBuilderCustomizer 를 사용할 수 있음
+     */
+    @Bean
+    public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+        ObjectMapper redisObjectMapper = createRedisObjectMapper();
+
+        return (builder) -> builder
+                .withCacheConfiguration("recommendedRoutine",
+                        RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofHours(6)) // 6시간 동안 캐시 유지
+                                .disableCachingNullValues() // null 값 캐싱 비활성화
+                                .serializeKeysWith(
+                                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                                )
+                                .serializeValuesWith(
+                                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper))
+                                ))
+                .withCacheConfiguration("categoryRecommendedRoutine",
+                        RedisCacheConfiguration.defaultCacheConfig()
+                                .entryTtl(Duration.ofHours(6)) // 6시간 동안 캐시 유지
+                                .disableCachingNullValues() // null 값 캐싱 비활성화
+                                .serializeKeysWith(
+                                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+                                )
+                                .serializeValuesWith(
+                                        RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper))
+                                ));
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/global/interceptor/LoggingInterceptor.java
+++ b/src/main/java/bitnagil/bitnagil_backend/global/interceptor/LoggingInterceptor.java
@@ -10,14 +10,27 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 public class LoggingInterceptor implements HandlerInterceptor {
 
+    private static final String START_TIME_ATTR = "startTime";
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        long startTime = System.currentTimeMillis();
+        request.setAttribute(START_TIME_ATTR, startTime);
+
         log.info("️⏹ [REQUEST] {} {}", request.getMethod(), request.getRequestURI());
         return true;
     }
 
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
-        log.info("⏹ [RESPONSE] {} {} - Status: {}", request.getMethod(), request.getRequestURI(), response.getStatus());
+        Long startTime = (Long) request.getAttribute(START_TIME_ATTR);
+        long endTime = System.currentTimeMillis();
+        long duration = (startTime != null) ? (endTime - startTime) : -1;
+
+        log.info("⏹ [RESPONSE] {} {} - Status: {} ({} ms)",
+                request.getMethod(),
+                request.getRequestURI(),
+                response.getStatus(),
+                duration);
     }
 }

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/response/RecommendedRoutineSearchResponse.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/response/RecommendedRoutineSearchResponse.java
@@ -17,7 +17,7 @@ public class RecommendedRoutineSearchResponse {
 
     // 추천 루틴 타입별 루틴, 서브루틴 리스트
     @Schema(description = "추천 루틴 타입을 key로 가지는 루틴 목록 Map입니다. Swagger에서는 additionalProp1처럼 보일 수 있습니다.")
-    Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> recommendedRoutines;
+    Map<String, List<RecommendedRoutineSearchResult>> recommendedRoutines;
     // 감정 구슬 enum 값
     @Schema(description = "감정 구슬 타입")
     EmotionMarbleType emotionMarbleType;

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineFactory.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineFactory.java
@@ -1,0 +1,116 @@
+package bitnagil.bitnagil_backend.recommendedRoutine.service;
+
+import bitnagil.bitnagil_backend.emotionMarble.domain.EmotionMarble;
+import bitnagil.bitnagil_backend.onboarding.domain.Case;
+import bitnagil.bitnagil_backend.onboarding.domain.Onboarding;
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.RecommendedRoutine;
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.RecommendedSubRoutine;
+import bitnagil.bitnagil_backend.recommendedRoutine.domain.enums.RecommendedRoutineType;
+import bitnagil.bitnagil_backend.recommendedRoutine.repository.RecommendedRoutineRepository;
+import bitnagil.bitnagil_backend.recommendedRoutine.repository.RecommendedSubRoutineRepository;
+import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedRoutineSearchResult;
+import bitnagil.bitnagil_backend.recommendedRoutine.response.RecommendedSubRoutineSearchResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 추천 루틴 관련 객체 생성, 초기화 책임을 담당하는 클래스입니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class RecommendedRoutineFactory {
+
+    private final RecommendedRoutineRepository recommendedRoutineRepository;
+    private final RecommendedSubRoutineRepository recommendedSubRoutineRepository;
+    private final RecommendedRoutineMapper recommendedRoutineMapper;
+
+    /**
+     * 맞춤추천 루틴을 제외한 카테고리별 추천 루틴, 서브루틴 응답을 생성하는 메서드
+     * 캐싱을 위해 서비스 클래스가 아닌 Factory 클래스로 분리
+     */
+    @Cacheable(cacheNames = "categoryRecommendedRoutine", key = "'categoryRecommendedRoutine'")
+    public Map<String, List<RecommendedRoutineSearchResult>> addCategoryRecommendedRoutines() {
+        Map<String, List<RecommendedRoutineSearchResult>> response = new HashMap<>();
+        RecommendedRoutineType[] values = RecommendedRoutineType.values();
+
+        for (RecommendedRoutineType value : values) {
+            // value가 PERSONALIZED가 아닌 경우에만 추천 루틴 조회
+            if (value == RecommendedRoutineType.PERSONALIZED) {
+                continue;
+            }
+            // 추천 루틴 조회
+            List<RecommendedRoutine> recommendedRoutines = recommendedRoutineRepository.findByRecommendedRoutineType(value);
+            List<RecommendedRoutineSearchResult> recommendedRoutineResults = buildRecommendedRoutineSearchResult(
+                    recommendedRoutines);
+            // Map에 값을 저장
+            response.put(value.name(), recommendedRoutineResults);
+        }
+
+        return response;
+    }
+
+    // 추천 서브루틴 응답 객체를 생성하여 리스트에 추가
+    public List<RecommendedRoutineSearchResult> buildRecommendedRoutineSearchResult(
+            List<RecommendedRoutine> recommendedRoutines) {
+        List<RecommendedRoutineSearchResult> recommendedRoutineResults = new ArrayList<>(); // 추천 루틴 응답 객체
+        // 추천 서브루틴 조회
+        for (RecommendedRoutine recommendedRoutine : recommendedRoutines) {
+            List<RecommendedSubRoutine> recommendedSubRoutines = recommendedSubRoutineRepository.findByRecommendedRoutine(recommendedRoutine);
+            List<RecommendedSubRoutineSearchResult> recommendedSubRoutineResults = new ArrayList<>();
+            // 추천 서브루틴 응답 객체 생성
+            addRecommendedSubRoutineToResponse(recommendedSubRoutines, recommendedSubRoutineResults);
+            // 추천 루틴 응답 객체 생성
+            addRecommendedRoutineToResponse(recommendedRoutine, recommendedSubRoutineResults, recommendedRoutineResults);
+        }
+        return recommendedRoutineResults;
+    }
+
+    // 추천루틴을 응답 객체에 추가하는 메서드
+    public void addRecommendedRoutineToResponse(RecommendedRoutine recommendedRoutine,
+                                                 List<RecommendedSubRoutineSearchResult> recommendedSubRoutineResults,
+                                                 List<RecommendedRoutineSearchResult> recommendedRoutineResults) {
+
+        RecommendedRoutineSearchResult recommendedRoutineResult =
+                recommendedRoutineMapper.toRecommendedRoutineSearchResult(recommendedRoutine, recommendedSubRoutineResults);
+        recommendedRoutineResults.add(recommendedRoutineResult);
+    }
+
+    // 추천 서브루틴을 응답 객체에 추가하는 메서드
+    public void addRecommendedSubRoutineToResponse(List<RecommendedSubRoutine> recommendedSubRoutines,
+                                                    List<RecommendedSubRoutineSearchResult> recommendedSubRoutineResults) {
+
+        for (RecommendedSubRoutine recommendedSubRoutine : recommendedSubRoutines) {
+            RecommendedSubRoutineSearchResult recommendedSubRoutineResult =
+                    recommendedRoutineMapper.toRecommendedSubRoutineSearchResult(recommendedSubRoutine);
+            recommendedSubRoutineResults.add(recommendedSubRoutineResult);
+        }
+    }
+
+    // 감정구슬에 따른 추천 루틴을 생성하는 메서드
+    public void makeEmotionMarbleResponse(EmotionMarble emotionMarble,
+                                           Map<String, List<RecommendedRoutineSearchResult>> response) {
+        Case resultCase = emotionMarble.getResultCase();
+        List<RecommendedRoutine> recommendedRoutines = recommendedRoutineRepository.findByResultCase(resultCase);
+        List<RecommendedRoutineSearchResult> recommendedRoutineResults = buildRecommendedRoutineSearchResult(
+                recommendedRoutines);
+        // 감정구슬에 따른 추천 루틴을 Map에 저장
+        response.get(RecommendedRoutineType.PERSONALIZED.name()).addAll(recommendedRoutineResults);
+    }
+
+    // 온보딩에 따른 추천 루틴을 생성하는 메서드
+    public void makeOnboardingResponse(Onboarding onboarding,
+                                        Map<String, List<RecommendedRoutineSearchResult>> response) {
+        Case resultCase = onboarding.getResultCase();
+        List<RecommendedRoutine> recommendedRoutines = recommendedRoutineRepository.findByResultCase(resultCase);
+        List<RecommendedRoutineSearchResult> recommendedRoutineResults = buildRecommendedRoutineSearchResult(
+                recommendedRoutines);
+        // 감정구슬에 따른 추천 루틴을 Map에 저장
+        response.get(RecommendedRoutineType.PERSONALIZED.name()).addAll(recommendedRoutineResults);
+    }
+}

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineMapper.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineMapper.java
@@ -59,7 +59,7 @@ public class RecommendedRoutineMapper {
 
     // 추천 카테고리 별 루틴, 서브루틴을 반환하는 DTO로 변환
     public RecommendedRoutineSearchResponse toRecommendedRoutineSearchResponse(
-        Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> response, EmotionMarble emotionMarble) {
+        Map<String, List<RecommendedRoutineSearchResult>> response, EmotionMarble emotionMarble) {
 
         return RecommendedRoutineSearchResponse.builder()
             .recommendedRoutines(response)

--- a/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/recommendedRoutine/service/RecommendedRoutineService.java
@@ -4,7 +4,6 @@ import bitnagil.bitnagil_backend.emotionMarble.domain.EmotionMarble;
 import bitnagil.bitnagil_backend.emotionMarble.repository.EmotionMarbleRepository;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
-import bitnagil.bitnagil_backend.onboarding.domain.Case;
 import bitnagil.bitnagil_backend.onboarding.domain.Onboarding;
 import bitnagil.bitnagil_backend.recommendedRoutine.domain.RecommendedRoutine;
 import bitnagil.bitnagil_backend.recommendedRoutine.domain.RecommendedSubRoutine;
@@ -20,12 +19,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,6 +39,7 @@ public class RecommendedRoutineService {
     private final EmotionMarbleRepository emotionMarbleRepository;
 
     private final RecommendedRoutineMapper recommendedRoutineMapper;
+    private final RecommendedRoutineFactory recommendedRoutineFactory;
     private final UserManager userManager;
 
     /**
@@ -51,18 +51,17 @@ public class RecommendedRoutineService {
 
         LocalDate nowDate = LocalDate.now();
 
+        // 맞춤추천을 제외한 이외의 카테고리에 대한 추천 루틴을 response 추가
+        Map<String, List<RecommendedRoutineSearchResult>> response = recommendedRoutineFactory.addCategoryRecommendedRoutines();
+
         // 카테고리 별 추천루틴에 대한 response 객체 생성
-        Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> response = new HashMap<>();
-        response.put(RecommendedRoutineType.PERSONALIZED, new ArrayList<>()); // 맞춤 루틴은 미리 초기화 한다.(감정구슬, 온보딩 결과를 넣기 위해)
+        response.put(RecommendedRoutineType.PERSONALIZED.name(), new ArrayList<>()); // 맞춤 루틴은 미리 초기화 한다.(감정구슬, 온보딩 결과를 넣기 위해)
 
         // 영속성 객체에 user를 저장하기 위해 user를 조회
         User persistedUser = userManager.getPersistedUser(user);
 
         // 맞춤 추천(감정구슬 + 온보딩)을 조회하고 response에 추가
         EmotionMarble emotionMarble = addPersonalizedRecommendedRoutine(persistedUser, nowDate, response);
-
-        // 맞춤추천 이외의 카테고리에 대한 추천 루틴을 response 추가
-        addCategoryRecommendedRoutines(response);
 
         return recommendedRoutineMapper.toRecommendedRoutineSearchResponse(response, emotionMarble);
     }
@@ -71,6 +70,7 @@ public class RecommendedRoutineService {
      * 추천 루틴 단건 조회
      */
     @Transactional(readOnly = true)
+    @Cacheable(cacheNames = "recommendedRoutine", key = "#recommendedRoutineId")
     public RecommendedRoutineSearchResult searchRecommendedRoutine(Long recommendedRoutineId) {
         RecommendedRoutine recommendedRoutine = recommendedRoutineRepository.findById(recommendedRoutineId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RECOMMENDED_ROUTINE));
@@ -86,94 +86,19 @@ public class RecommendedRoutineService {
         return recommendedRoutineMapper.toRecommendedRoutineSearchResult(recommendedRoutine, recommendedSubRoutineSearchResults);
     }
 
-    private void addCategoryRecommendedRoutines(Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> response) {
-        RecommendedRoutineType[] values = RecommendedRoutineType.values();
-
-        for (RecommendedRoutineType value : values) {
-            // value가 PERSONALIZED가 아닌 경우에만 추천 루틴 조회
-            if (value == RecommendedRoutineType.PERSONALIZED) {
-                continue;
-            }
-            // 추천 루틴 조회
-            List<RecommendedRoutine> recommendedRoutines = recommendedRoutineRepository.findByRecommendedRoutineType(value);
-            List<RecommendedRoutineSearchResult> recommendedRoutineResults = buildRecommendedRoutineSearchResult(
-                recommendedRoutines);
-            // Map에 값을 저장
-            response.put(value, recommendedRoutineResults);
-        }
-    }
-
     private EmotionMarble addPersonalizedRecommendedRoutine(User user, LocalDate nowDate,
-        Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> response) {
+        Map<String, List<RecommendedRoutineSearchResult>> response) {
         // 감정구슬(당일에 감정구슬을 선택한 경우만 조회)
         EmotionMarble emotionMarble = emotionMarbleRepository.findByUserIdAndDateIs(user.getUserId(), nowDate);
         if(emotionMarble != null) { // 조회 결과가 존재하는 경우
-            makeEmotionMarbleResponse(emotionMarble, response);
+            recommendedRoutineFactory.makeEmotionMarbleResponse(emotionMarble, response);
         }
 
         // 온보딩 결과에 따른 추천 루틴 조회
         Onboarding onboarding = user.getOnboarding();
         if (onboarding != null) { // 온보딩을 수행한 유저의 경우(온보딩은 필수지만 방어 로직으로 추가)
-            makeOnboardingResponse(onboarding, response);
+            recommendedRoutineFactory.makeOnboardingResponse(onboarding, response);
         }
         return emotionMarble;
-    }
-
-    private List<RecommendedRoutineSearchResult> buildRecommendedRoutineSearchResult(
-        List<RecommendedRoutine> recommendedRoutines) {
-        List<RecommendedRoutineSearchResult> recommendedRoutineResults = new ArrayList<>(); // 추천 루틴 응답 객체
-        // 추천 서브루틴 조회
-        for (RecommendedRoutine recommendedRoutine : recommendedRoutines) {
-            List<RecommendedSubRoutine> recommendedSubRoutines = recommendedSubRoutineRepository.findByRecommendedRoutine(recommendedRoutine);
-            List<RecommendedSubRoutineSearchResult> recommendedSubRoutineResults = new ArrayList<>();
-            // 추천 서브루틴 응답 객체 생성
-            addRecommendedSubRoutineToResponse(recommendedSubRoutines, recommendedSubRoutineResults);
-            // 추천 루틴 응답 객체 생성
-            addRecommendedRoutineToResponse(recommendedRoutine, recommendedSubRoutineResults, recommendedRoutineResults);
-        }
-        return recommendedRoutineResults;
-    }
-
-    // 추천루틴을 응답 객체에 추가하는 메서드
-    private void addRecommendedRoutineToResponse(RecommendedRoutine recommendedRoutine,
-                                                 List<RecommendedSubRoutineSearchResult> recommendedSubRoutineResults,
-                                                 List<RecommendedRoutineSearchResult> recommendedRoutineResults) {
-
-        RecommendedRoutineSearchResult recommendedRoutineResult =
-            recommendedRoutineMapper.toRecommendedRoutineSearchResult(recommendedRoutine, recommendedSubRoutineResults);
-        recommendedRoutineResults.add(recommendedRoutineResult);
-    }
-
-    // 추천 서브루틴을 응답 객체에 추가하는 메서드
-    private void addRecommendedSubRoutineToResponse(List<RecommendedSubRoutine> recommendedSubRoutines,
-                                                    List<RecommendedSubRoutineSearchResult> recommendedSubRoutineResults) {
-
-        for (RecommendedSubRoutine recommendedSubRoutine : recommendedSubRoutines) {
-            RecommendedSubRoutineSearchResult recommendedSubRoutineResult =
-                recommendedRoutineMapper.toRecommendedSubRoutineSearchResult(recommendedSubRoutine);
-            recommendedSubRoutineResults.add(recommendedSubRoutineResult);
-        }
-    }
-
-    // 감정구슬에 따른 추천 루틴을 생성하는 메서드
-    private void makeEmotionMarbleResponse(EmotionMarble emotionMarble,
-                                           Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> response) {
-        Case resultCase = emotionMarble.getResultCase();
-        List<RecommendedRoutine> recommendedRoutines = recommendedRoutineRepository.findByResultCase(resultCase);
-        List<RecommendedRoutineSearchResult> recommendedRoutineResults = buildRecommendedRoutineSearchResult(
-            recommendedRoutines);
-        // 감정구슬에 따른 추천 루틴을 Map에 저장
-        response.get(RecommendedRoutineType.PERSONALIZED).addAll(recommendedRoutineResults);
-    }
-
-    // 온보딩에 따른 추천 루틴을 생성하는 메서드
-    private void makeOnboardingResponse(Onboarding onboarding,
-                                        Map<RecommendedRoutineType, List<RecommendedRoutineSearchResult>> response) {
-        Case resultCase = onboarding.getResultCase();
-        List<RecommendedRoutine> recommendedRoutines = recommendedRoutineRepository.findByResultCase(resultCase);
-        List<RecommendedRoutineSearchResult> recommendedRoutineResults = buildRecommendedRoutineSearchResult(
-            recommendedRoutines);
-        // 감정구슬에 따른 추천 루틴을 Map에 저장
-        response.get(RecommendedRoutineType.PERSONALIZED).addAll(recommendedRoutineResults);
     }
 }


### PR DESCRIPTION
## 작업 내역
- redis 캐싱 적용
- 추천 루틴 단건 조회 캐싱
- 추천 루틴 조회(맞춤추천 제외) 캐싱
- 추천 루틴 조회 캐싱을 위한 로직 분리(RecommendedRoutinFactory 생성)
- 캐시 이름마다 서로 다른 RedisCacheManager 설정
## 고민한 사항
- @Cacheable 을 적용할때 같은 클래스 내에서 부모 메서드가 @Cacheable이 붙은 자식 메서드를 호출하면 캐싱이 적용되지 않습니다.
- 이에 따라서 자기참조를 수행하는 방식과 서비스 로직을 분리하는 방식 중 서비스 로직을 분리하는 방식을 택했고 그에 따른 결과가 RecommendedRoutinFactory 객체입니다.(자기참조는 순환참조의 문제가 있고, 좋은 시스템 디자인이 아니라고 판단)
- Factory 객체는 현재 다른 도메인 영역에서는 순수 객체 초기화의 목적을 두지만, 이번에는 캐싱 적용 및 불필요한 중복 로직을 제거하고, 실제 서비스 로직단에서 공통으로 사용되는 함수들을 관리할 수 있는 객체의 필요성으로 인해 순수객체 초기화는 아니지만 특정 응답값을 생성한다는 목적은 동일하다고 판단해서 Factory 객체로 만들었습니다.
- 이부분 한번 확인 부탁드립니다.
## 리뷰 요청사항