### PR TITLE
[T3-186] 회원 탈퇴 사유 추가

### DIFF
--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/UserAuthController.java
@@ -4,6 +4,7 @@ import bitnagil.bitnagil_backend.user.request.UserAgreementsRequest;
 import bitnagil.bitnagil_backend.user.request.UserLoginRequest;
 import org.springframework.web.bind.annotation.*;
 
+import bitnagil.bitnagil_backend.user.request.UserWithdrawalRequest;
 import bitnagil.bitnagil_backend.user.response.UserTokenResponse;
 import bitnagil.bitnagil_backend.global.annotation.CurrentUser;
 import bitnagil.bitnagil_backend.user.controller.spec.UserAuthSpec;
@@ -44,8 +45,9 @@ public class UserAuthController implements UserAuthSpec {
     }
 
     @PostMapping("/withdrawal")
-    public CustomResponseDto<Object> withdrawal(@CurrentUser User user) {
-        userAuthService.withdrawal(user);
+    public CustomResponseDto<Object> withdrawal(@RequestBody UserWithdrawalRequest userWithdrawalRequest,
+                                                @CurrentUser User user) {
+        userAuthService.withdrawal(userWithdrawalRequest, user);
 
         return CustomResponseDto.from(null);
     }

--- a/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/controller/spec/UserAuthSpec.java
@@ -3,6 +3,7 @@ package bitnagil.bitnagil_backend.user.controller.spec;
 import bitnagil.bitnagil_backend.user.request.UserAgreementsRequest;
 import bitnagil.bitnagil_backend.user.request.UserLoginRequest;
 
+import bitnagil.bitnagil_backend.user.request.UserWithdrawalRequest;
 import bitnagil.bitnagil_backend.user.response.UserTokenResponse;
 import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.response.CustomResponseDto;
@@ -56,7 +57,7 @@ public interface UserAuthSpec {
     @ApiErrorCodeExamples({
             ErrorCode.KAKAO_FEIGN_CALL_FAILED, ErrorCode.KAKAO_UNLINK_FAILED, ErrorCode.APPLE_FEIGN_CALL_FAILED
     })
-    CustomResponseDto<Object> withdrawal(User user);
+    CustomResponseDto<Object> withdrawal(UserWithdrawalRequest userWithdrawalRequest, User user);
 
     @Operation(summary = "유저가 최초 회원가입 시 약관 동의를 처리합니다.")
     @ApiErrorCodeExamples({

--- a/src/main/java/bitnagil/bitnagil_backend/user/domain/User.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/domain/User.java
@@ -50,6 +50,8 @@ public class User extends BaseTimeEntity {
     private Boolean agreedToPrivacyPolicy; // 개인정보 수집 동의
     private Boolean isOverFourteen; // 14세 이상 여부
 
+    private String reasonOfWithdrawal; // 탈퇴 사유
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "onboarding_id")
     private Onboarding onboarding;
@@ -74,6 +76,10 @@ public class User extends BaseTimeEntity {
     public void updateOnboarding(Onboarding onboarding) {
         this.onboarding = onboarding;
         this.role = Role.USER; // 온보딩 완료 후 권한을 USER로 변경
+    }
+
+    public void updateUserReasonOfWithdrawal(String reasonOfWithdrawal) {
+        this.reasonOfWithdrawal = reasonOfWithdrawal;
     }
 
     // todo: 운영 반영 후 이슈가 없으면 제거

--- a/src/main/java/bitnagil/bitnagil_backend/user/request/UserWithdrawalRequest.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/request/UserWithdrawalRequest.java
@@ -1,0 +1,15 @@
+package bitnagil.bitnagil_backend.user.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(description = "회원 탈퇴 요청 DTO")
+public class UserWithdrawalRequest {
+
+    @Schema(description = "서비스 탈퇴 사유입니다.", example = "루틴을 수행하기 어려워요.")
+    private String reasonOfWithdrawal;
+}

--- a/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
+++ b/src/main/java/bitnagil/bitnagil_backend/user/service/UserAuthService.java
@@ -18,6 +18,7 @@ import bitnagil.bitnagil_backend.global.errorcode.ErrorCode;
 import bitnagil.bitnagil_backend.global.exception.CustomException;
 import bitnagil.bitnagil_backend.user.repository.UserRepository;
 import bitnagil.bitnagil_backend.user.domain.enums.SocialType;
+import bitnagil.bitnagil_backend.user.request.UserWithdrawalRequest;
 import bitnagil.bitnagil_backend.user.response.UserTokenResponse;
 import bitnagil.bitnagil_backend.user.domain.User;
 import bitnagil.bitnagil_backend.user.domain.enums.Role;
@@ -86,11 +87,14 @@ public class UserAuthService {
 
     // 회원탈퇴 - 회원 관련 정보 삭제 및 소셜과 연결 끊기
     @Transactional
-    public void withdrawal(User user) {
+    public void withdrawal(UserWithdrawalRequest request, User user) {
         // 변경 감지를 위해 영속 상태로 설정
         User persistedUser = userManager.getPersistedUser(user);
 
         invalidateToken(persistedUser);
+
+        persistedUser.updateUserReasonOfWithdrawal(request.getReasonOfWithdrawal());
+        userRepository.flush(); // user의 필드 변경을 DB에 동기화
 
         // 회원 삭제 (delete() 호출 시 @SQLDelete 어노테이션에 의해 role은 WITHDRAWN로 deleted_at은 NOW()로 변경됨)
         userRepository.delete(user);

--- a/src/main/resources/db/migration/V10__add_reason_of_withdrawal_to_user.sql
+++ b/src/main/resources/db/migration/V10__add_reason_of_withdrawal_to_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user
+    ADD COLUMN reason_of_withdrawal VARCHAR(255) NULL;


### PR DESCRIPTION
## 작업 내역
- User에 탈퇴 사유 필드 추가 및 회원 탈퇴 API 수정
- 서비스 로직 내에 user.delete() 메서드로 변경이 저장되지 않아 flush를 통해 해결하였습니다.

## 고민한 사항

## 리뷰 요청사항
- 작업 내역 기반으로 검토 부탁드립니다!