### PR TITLE
refactor: 뱃지 응답 필드 정리 — badgeTitle/badgeDescription + badges[] 필드 축소

### DIFF
--- a/bitnagil-domain/src/main/java/bitnagil/badge/dto/response/BadgeResponse.java
+++ b/bitnagil-domain/src/main/java/bitnagil/badge/dto/response/BadgeResponse.java
@@ -13,12 +13,6 @@ public class BadgeResponse {
     @Schema(description = "뱃지 타입")
     private BadgeType badgeType;
 
-    @Schema(description = "뱃지 타이틀", example = "체크 전문가")
-    private String title;
-
-    @Schema(description = "뱃지 설명", example = "큰 성취를 이루셨군요!")
-    private String description;
-
     @Schema(description = "뱃지 이미지 URL")
     private String imageUrl;
 

--- a/bitnagil-domain/src/main/java/bitnagil/badge/dto/response/MonthlyBadgeResponse.java
+++ b/bitnagil-domain/src/main/java/bitnagil/badge/dto/response/MonthlyBadgeResponse.java
@@ -12,10 +12,10 @@ public class MonthlyBadgeResponse {
 
     @Schema(description = "그 달을 대표하는 칭호. 획득 0개=예비 전문가, 1개=그 뱃지 이름, "
         + "2개=능숙한 전문가, 3개=완벽한 전문가", example = "능숙한 전문가")
-    private String title;
+    private String badgeTitle;
 
     @Schema(description = "칭호에 대응하는 대표 문구", example = "하나만 더 모으면 이번 달이 완성돼요!")
-    private String description;
+    private String badgeDescription;
 
     @Schema(description = "그 달 획득한 뱃지 아이콘 목록 (0개인 달은 예비 전문가 1건)")
     private List<BadgeResponse> badges;

--- a/bitnagil-domain/src/main/java/bitnagil/badge/service/BadgeMapper.java
+++ b/bitnagil-domain/src/main/java/bitnagil/badge/service/BadgeMapper.java
@@ -12,12 +12,9 @@ import org.springframework.stereotype.Component;
 public class BadgeMapper {
 
     public BadgeResponse toBadgeResponse(Badge badge) {
-        BadgeType type = badge.getBadgeType();
         return BadgeResponse.builder()
-            .badgeType(type)
-            .title(type.getTitle())
-            .description(type.getDescription())
-            .imageUrl(type.getImageUrl())
+            .badgeType(badge.getBadgeType())
+            .imageUrl(badge.getBadgeType().getImageUrl())
             .acquiredAt(badge.getCreatedAt())
             .build();
     }
@@ -27,39 +24,43 @@ public class BadgeMapper {
         BadgeType type = BadgeType.RESERVE_EXPERT;
         return BadgeResponse.builder()
             .badgeType(type)
-            .title(type.getTitle())
-            .description(type.getDescription())
             .imageUrl(type.getImageUrl())
             .acquiredAt(null)
             .build();
     }
 
     /**
-     * 그 달 획득 뱃지 목록을 대표 칭호(title/description) + 아이콘 목록으로 묶습니다.
-     * 대표 칭호는 획득 개수로 결정됩니다: 0·1개=대표 뱃지(예비 전문가 또는 그 뱃지) 자체, 2개 이상=집계 칭호({@link BadgeTier}).
+     * 그 달 획득 뱃지 목록을 대표 칭호(badgeTitle/badgeDescription) + 아이콘 목록(badges)으로 묶습니다.
+     * badges[] 항목은 아이콘 표시용이라 title/description을 담지 않으므로, 대표 칭호는 원본
+     * {@link Badge}/{@link BadgeType}에서 직접 계산합니다: 0개=예비 전문가, 1개=그 뱃지 자체,
+     * 2개 이상=집계 칭호({@link BadgeTier}).
      */
     public MonthlyBadgeResponse toMonthlyBadgeResponse(List<Badge> monthlyBadges) {
-        List<BadgeResponse> badges = monthlyBadges.isEmpty()
-            ? List.of(toReserveDefaultResponse())
-            : monthlyBadges.stream().map(this::toBadgeResponse).toList();
+        if (monthlyBadges.isEmpty()) {
+            BadgeType reserve = BadgeType.RESERVE_EXPERT;
+            return MonthlyBadgeResponse.builder()
+                .badgeTitle(reserve.getTitle())
+                .badgeDescription(reserve.getDescription())
+                .badges(List.of(toReserveDefaultResponse()))
+                .build();
+        }
 
-        String title;
-        String description;
-        if (badges.size() >= 2) {
-            BadgeTier tier = BadgeTier.from(badges.size());
-            title = tier.getTitle();
-            description = tier.getDescription();
+        String badgeTitle;
+        String badgeDescription;
+        if (monthlyBadges.size() == 1) {
+            BadgeType type = monthlyBadges.get(0).getBadgeType();
+            badgeTitle = type.getTitle();
+            badgeDescription = type.getDescription();
         } else {
-            // 0개(예비 전문가 기본)·1개(그 뱃지) 모두 목록의 대표 뱃지가 곧 칭호가 된다.
-            BadgeResponse representative = badges.get(0);
-            title = representative.getTitle();
-            description = representative.getDescription();
+            BadgeTier tier = BadgeTier.from(monthlyBadges.size());
+            badgeTitle = tier.getTitle();
+            badgeDescription = tier.getDescription();
         }
 
         return MonthlyBadgeResponse.builder()
-            .title(title)
-            .description(description)
-            .badges(badges)
+            .badgeTitle(badgeTitle)
+            .badgeDescription(badgeDescription)
+            .badges(monthlyBadges.stream().map(this::toBadgeResponse).toList())
             .build();
     }
 }


### PR DESCRIPTION
대표 칭호를 badgeTitle/badgeDescription으로 명명하고, 이미 대표값이 있으니 개별 badges[] 항목의 title/description은 제거(badgeType/imageUrl/acquiredAt만 유지).

- BadgeResponse: title/description 필드 제거
- MonthlyBadgeResponse: title→badgeTitle, description→badgeDescription
- BadgeMapper: 대표값 추출을 BadgeResponse가 아닌 원본 Badge/BadgeType에서 직접 계산하도록 재설계
- 로컬 서버로 0/1/2/3개 케이스 전부 재검증 완료

## 작업 내역

## 고민한 사항

## 리뷰 요청사항